### PR TITLE
修复HOTFIX_DEBUG_SYMBOL模式下的mdb文件写入冲突

### DIFF
--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -253,7 +253,11 @@ namespace XLua
 #endif
             init(assembly);
 
-            if (assembly.MainModule.Types.Any(t => t.Name == "__XLUA_GEN_FLAG")) return;
+			if (assembly.MainModule.Types.Any(t => t.Name == "__XLUA_GEN_FLAG"))
+			{
+				Clean(assembly);
+				return;
+			}
 
             assembly.MainModule.Types.Add(new TypeDefinition("__XLUA_GEN", "__XLUA_GEN_FLAG", Mono.Cecil.TypeAttributes.Class,
                 objType));
@@ -269,7 +273,8 @@ namespace XLua
             {
                 if (!injectType(assembly, hotfixAttributeType, type))
                 {
-                    return;
+					Clean(assembly);
+					return;
                 }
             }
 #if HOTFIX_DEBUG_SYMBOLS
@@ -278,10 +283,18 @@ namespace XLua
 #else
             assembly.Write(INTERCEPT_ASSEMBLY_PATH);
 #endif
-
-            Debug.Log("hotfix inject finish!");
+			Clean(assembly);
+			Debug.Log("hotfix inject finish!");
         }
-        
+
+		static void Clean(AssemblyDefinition assembly)
+		{
+			if (assembly.MainModule.SymbolReader != null)
+			{
+				assembly.MainModule.SymbolReader.Dispose();
+			}
+		}
+
         static OpCode[] ldargs = new OpCode[] { OpCodes.Ldarg_0, OpCodes.Ldarg_1, OpCodes.Ldarg_2, OpCodes.Ldarg_3 };
 
         static readonly int MAX_OVERLOAD = 100;


### PR DESCRIPTION
mdb写入冲突是由于调用HotfixInject时，先读取了mdb文件，但是未释放，在return之前释放掉即可解决此问题。

另：方便使用者打包起见，建议类似这种地方`#if HOTFIX_ENABLE`可改为`#if HOTFIX_ENABLE || !UNITY_EDITOR`