### PR TITLE
修复某些情况下注入代码写回dll文件时报错的问题，错误类似这种：AssemblyResolutionException: Failed t…

### DIFF
--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -49,6 +49,9 @@ namespace XLua
             inParam = luaFunctionType.Methods.Single(m => m.Name == "InParam");
             inParams = luaFunctionType.Methods.Single(m => m.Name == "InParams");
             outParam = luaFunctionType.Methods.Single(m => m.Name == "OutParam");
+
+			var resolver = assembly.MainModule.AssemblyResolver as BaseAssemblyResolver;
+			resolver.AddSearchDirectory("./Library/UnityAssemblies");
         }
 
         static List<TypeDefinition> hotfix_delegates = null;


### PR DESCRIPTION
实际使用的时候，导出到文件时报错，看上去像是找不到UnityEngine.UI引用的样子，进去调试了代码，发现导出时默认路径只有当前路径和bin，添加上搜索路径后解决了。但是我创建了一个空工程后，导入原始的xlua，在代码中引用UnityEngine.UI，貌似却可以正常导出。可能跟我们的项目里各种复杂的引用有关吧。。总之，建议解决一下。