### PR TITLE
过滤枚举的Obsolute字段

### DIFF
--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
@@ -29,7 +29,7 @@ namespace CSObjectWrap
 			
 			Utils.BeginClassRegister(typeof(<%=CsFullTypeName(type)%>), L, null, <%=fields.Length + 1%>, 0, 0);
             <% ForEachCsList(fields, function(field) 
-			if field.Name == "value__" then return end
+			if field.Name == "value__" or IsObsolute(field) then return end
 			%>
             Utils.RegisterObject(L, translator, Utils.CLS_IDX, "<%=field.Name%>", <%=CsFullTypeName(type)%>.<%=field.Name%>);
             <%end)%>
@@ -53,7 +53,7 @@ namespace CSObjectWrap
 			    <%
                 local is_first = true
 				ForEachCsList(fields, function(field, i) 
-			        if field.Name == "value__" then return end
+			        if field.Name == "value__" or IsObsolute(field) then return end
 			    %><%=(is_first and "" or "else ")%>if (LuaAPI.xlua_is_eq_str(L, 1, "<%=field.Name%>"))
                 {
                     translator.Push<%=CSVariableName(type)%>(L, <%=CsFullTypeName(type)%>.<%=field.Name%>);

--- a/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
+++ b/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
@@ -247,6 +247,11 @@ function IsParams(pi)
     return pi:IsDefined(paramsAttriType, false)
 end
 
+local obsoluteAttriType = typeof(CS.System.ObsoleteAttribute)
+function IsObsolute(f)
+    return f:IsDefined(obsoluteAttriType, false)
+end
+
 local objectType = typeof(CS.System.Object)
 function GetSelfStatement(t)
     local fulltypename = CsFullTypeName(t)


### PR DESCRIPTION
编译Android平台的时候会报类似如下编译错误（Editor中可以正常编译）：

Assets/XLua/Gen/EnumWrap.cs(149,106): error CS0117: `UnityEngine.RuntimePlatform' does not contain a definition for `BB10Player'

测试环境：Unity 5.4.3f1

在代码生成模版里屏蔽掉Obsolute的字段