### PR TITLE
一些修复，详见commit message

### DIFF
--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -232,7 +232,7 @@ namespace XLua
                 }
                 foreach (var method in type.Methods)
                 {
-                    if (method.Name != ".cctor" && !method.IsAbstract && !method.IsPInvokeImpl)
+                    if (method.Name != ".cctor" && !method.IsAbstract && !method.IsPInvokeImpl && method.Body != null)
                     {
                         if ((method.HasGenericParameters || genericInOut(assembly, method)) ? !injectGenericMethod(assembly, method, hotfixType, stateTable) :
                             !injectMethod(assembly, method, hotfixType, stateTable))

--- a/Assets/XLua/Src/Editor/Template/LuaDelegateBridge.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaDelegateBridge.tpl.txt
@@ -29,6 +29,8 @@ namespace XLua
 		if has_return then out_num = out_num + 1 end
 		%>
 		public <%=return_type_name%> <%=CSVariableName(delegate.ReturnType)%>(<%ForEachCsList(parameters, function(parameter, pi) 
+			local pname = parameter.Name
+			if pname == '' or pname == 'object' then pname = 'p' .. tostring(pi) end
 			if pi ~= 0 then 
 				%>, <% 
 			end
@@ -37,7 +39,7 @@ namespace XLua
 			elseif parameter.ParameterType.IsByRef then
 				%>ref <%
 			end 
-			%><%=CsFullTypeName(parameter.ParameterType)%> <%=parameter.Name%><% 
+			%><%=CsFullTypeName(parameter.ParameterType)%> <%=pname%><% 
 		end) %>)
 		{
 #if THREAD_SAFT || HOTFIX_ENABLE
@@ -54,8 +56,10 @@ namespace XLua
                 local param_count = parameters.Length
                 local has_v_params = param_count > 0 and parameters[param_count - 1].IsParamArray
                 ForEachCsList(parameters, function(parameter, pi) 
+					local pname = parameter.Name
+					if pname == '' or pname == 'object' then pname = 'p' .. tostring(pi) end
                     if parameter.IsIn or not parameter.IsOut then 
-                        %><%=GetPushStatement(parameter.ParameterType, parameter.Name, has_v_params and pi == param_count - 1)%>;
+                        %><%=GetPushStatement(parameter.ParameterType, pname, has_v_params and pi == param_count - 1)%>;
                 <% 
                     end
                 end) %>

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -473,7 +473,7 @@ namespace XLua
             for (int i = 0; i < props.Length; ++i)
             {
                 PropertyInfo prop = props[i];
-                if (prop.Name == "Item")
+                if (prop.Name == "Item" && prop.GetIndexParameters().Length > 0)
                 {
                     items.Add(prop);
                 }


### PR DESCRIPTION
1.修复某些情况生成代理类的时候，参数名为空导致的编译失败
2.修复导入一个带有名为Item的自定义属性的类时报错的问题（this[]这种生成的Item属性有参数，靠这个区分）
