### PR TITLE
增加：对带限定泛型类型扩展方法的支持

### DIFF
--- a/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
+++ b/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
@@ -142,7 +142,10 @@ function CsFullTypeName(t)
         return CsFullTypeName(t:GetElementType()) .. '[' .. string.rep(',', t:GetArrayRank() - 1) .. ']'
     elseif t.IsByRef then
         return CsFullTypeName(t:GetElementType())
+    elseif t.IsGenericParameter then
+        return CsFullTypeName(t.BaseType)
     end
+
     local name = t.FullName:gsub("&", ""):gsub("%+", ".") 
     if not t.IsGenericType then 
         return friendlyNameMap[name] or name
@@ -268,12 +271,25 @@ function GetSelfStatement(t)
     
 end
 
+local function getSafeFullName(t)
+    if t == nil then
+        return ""
+    end
+
+    if t.IsGenericParameter then
+        return getSafeFullName(t.BaseType)
+    end
+
+    return t.FullName:gsub("&", "")
+end
+
 function GetPushStatement(t, variable, is_v_params)
     if is_v_params then
 	    local item_push = GetPushStatement(t:GetElementType(), variable..'[__gen_i]')
 		return 'for (int __gen_i = 0; __gen_i < ' .. variable .. '.Length; ++__gen_i) ' .. item_push
 	end
-    local testname = t.FullName:gsub("&", "")
+    
+    local testname = getSafeFullName(t)
     if fixPush[testname] then
         return fixPush[testname] .. "(L, ".. variable ..")" 
     elseif genPushAndUpdateTypes[t] then
@@ -293,12 +309,12 @@ function GetUpdateStatement(t, idx, variable)
 end
 
 function JustLuaType(t)
-    return notranslator[t.FullName:gsub("&", "")]
+    return notranslator[getSafeFullName(t)]
 end
 
 function CallNeedTranslator(overload, isdelegate)
     if not overload.IsStatic and not isdelegate then return true end
-	local ret_type_name = overload.ReturnType.FullName:gsub("&", "")
+	local ret_type_name = getSafeFullName(overload.ReturnType)
     if not notranslator[ret_type_name] then return true end 
     local parameters = overload:GetParameters()
     return IfAny(overload:GetParameters(), function(parameter) return not notranslator[parameter.ParameterType.FullName:gsub("&", "")] end)


### PR DESCRIPTION
最近在整合DOTween到项目中，这个库中包含了大量的泛型扩展方法。

期望能得到类似这样的接口调用（和C#原生实现接近）：
local currentTweener = transform:DOLocalMoveX(-1280,duration)
                                                      :OnComplete(function() log:trace("tween completed") end)
                                                      :Play()

其中的两个扩展方法声明为：
public static T OnComplete<T>(this T t, TweenCallback action) where T : Tween
public static T Play<T>(this T t) where T : Tween

目前在xLua中是会直接忽略掉所有泛型方法的，做了下调整，让其为带类型约束的扩展方法所对应的类也生成lua接口。

在Unity5.4.3f1、DOTween1.1.340下测试通过。