### PR TITLE
修正：带泛型的扩展方法导致生成编译报错的问题

### DIFF
--- a/Assets/XLua/Examples/09_GenericMethod/Foo.cs
+++ b/Assets/XLua/Examples/09_GenericMethod/Foo.cs
@@ -95,4 +95,9 @@ public static class FooExtension
     {
         Debug.Log(string.Format("Extension2<{0},{1}>", typeof (T1), typeof (T2)));
     }
+
+    public static T UnsupportedExtension<T>(this GameObject obj) where T : Component
+    {
+        return obj.GetComponent<T>();
+    }
 }

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -1218,6 +1218,7 @@ namespace XLua
             if (!method.ContainsGenericParameters)
                 return true;
             var methodParameters = method.GetParameters();
+            var hasValidGenericParameter = false;
             for (var i = 0; i < methodParameters.Length; i++)
             {
                 var parameterType = methodParameters[i].ParameterType;
@@ -1226,9 +1227,10 @@ namespace XLua
                     var parameterConstraints = parameterType.GetGenericParameterConstraints();
                     if (parameterConstraints.Length == 0 || !parameterConstraints[0].IsClass)
                         return false;
+                    hasValidGenericParameter = true;
                 }
             }
-            return true;
+            return hasValidGenericParameter;
         }
 
         public static bool IsSupportedExtensionMethod(MethodBase method,Type extendedType)
@@ -1239,6 +1241,7 @@ namespace XLua
             if (methodParameters.Length < 1)
                 return false;
 
+            var hasValidGenericParameter = false;
             for (var i = 0; i < methodParameters.Length; i++)
             {
                 var parameterType = methodParameters[i].ParameterType;
@@ -1249,6 +1252,7 @@ namespace XLua
                         var parameterConstraints = parameterType.GetGenericParameterConstraints();
                         if (parameterConstraints.Length == 0 || !parameterConstraints[0].IsAssignableFrom(extendedType))
                             return false;
+                        hasValidGenericParameter = true;
                     }
                     else if (!parameterType.IsAssignableFrom(extendedType))
                         return false;
@@ -1258,9 +1262,10 @@ namespace XLua
                     var parameterConstraints = parameterType.GetGenericParameterConstraints();
                     if (parameterConstraints.Length == 0 || !parameterConstraints[0].IsClass)
                         return false;
+                    hasValidGenericParameter = true;
                 }
             }
-            return true;
+            return hasValidGenericParameter || !method.ContainsGenericParameters;
         }
 
         private static Type getExtendedType(MethodInfo method)


### PR DESCRIPTION
修正：类似NGUITools.AddMissingComponent<T>(this GameObject) where T:Component导致代码生成编译不过的问题