### PR TITLE
添加PreferIndexer标记，让用户选择在lua端访问对象成员的时候，是否会优先适用于C#端的this[indexer]索引运算符

### DIFF
--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -308,7 +308,7 @@ namespace CSObjectWrapEditor
                 .GroupBy(method => method.Name, (k, v) => new { Name = k, Overloads = v.Cast<MethodBase>().OrderBy(mb => mb.GetParameters().Length).ToList() }).ToList());
 
             parameters.Set("indexers", type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                .Where(method => method.Name == "get_Item" && method.GetParameters().Length == 1 /*&& method.GetParameters()[0].ParameterType != typeof(string)*/ && isClassPreferIndexer(type))
+                .Where(method => method.Name == "get_Item" && method.GetParameters().Length == 1 && (isClassPreferIndexer(type) || method.GetParameters()[0].ParameterType != typeof(string)))
                 .ToList());
 
             parameters.Set("newindexers", type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -850,11 +850,15 @@ namespace CSObjectWrapEditor
                                     from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
                                     where !method.ContainsGenericParameters && method.IsDefined(typeof(ExtensionAttribute), false)
                                     select method;
+
+            var prefer_indexer_types = PreferIndexer;
+
             GenOne(typeof(DelegateBridgeBase), (type, type_info) =>
             {
                 type_info.Set("wraps", wraps.ToList());
                 type_info.Set("itf_bridges", itf_bridges.ToList());
                 type_info.Set("extension_methods", extension_methods.ToList());
+                type_info.Set("prefer_indexer_types", prefer_indexer_types.ToList());
             }, templateRef.LuaRegister, textWriter);
             textWriter.Close();
         }

--- a/Assets/XLua/Src/Editor/Template/LuaRegister.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaRegister.tpl.txt
@@ -48,6 +48,7 @@ namespace XLua
 	    <%
 		local type_to_methods = {}
 		local seq_tbl = {}
+
 		ForEachCsList(extension_methods, function(extension_method, idx)
 		    local parameters = extension_method:GetParameters()
 			local type = parameters[0].ParameterType
@@ -72,6 +73,13 @@ namespace XLua
 				<%  end%>
 				}},
 				<%end%>
+			};
+
+			prefer_indexer_types = new List<Type>()
+			{
+				<%ForEachCsList(prefer_indexer_types, function(type, idx)%>
+				typeof(<%=CsFullTypeName(type)%>),
+				<%end)%>
 			};
 		}
 	}

--- a/Assets/XLua/Src/GenAttributes.cs
+++ b/Assets/XLua/Src/GenAttributes.cs
@@ -63,6 +63,12 @@ namespace XLua
 
     }
 
+    //如果希望某种类型更倾向于在Lua端使用Indexer的访问方式
+    public class PreferIndexerAttribute : Attribute
+    {
+
+    }
+
     public enum HotfixFlag
     {
         Stateless = 0,

--- a/Assets/XLua/Src/GenConfig.cs
+++ b/Assets/XLua/Src/GenConfig.cs
@@ -22,6 +22,9 @@ namespace XLua
 
         //黑名单
         List<List<string>> BlackList { get; }
+
+        //倾向于索引运算符的类型
+        List<Type> PreferIndexerList { get; }
     }
 
     public interface GCOptimizeConfig

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -1290,13 +1290,12 @@ namespace XLua
             return firstParameterConstraint;
         }
 
-        private static List<Type> preferIndexerTypes = null;
-
+        private static List<Type> prefer_indexer_types = null;
         private static bool isClassPreferIndexer(Type theType)
         {
-            if (preferIndexerTypes == null)
+            if (prefer_indexer_types == null)
             {
-                preferIndexerTypes = new List<Type>();
+                prefer_indexer_types = new List<Type>();
                 foreach (var type in GetAllTypes())
                 {
                     if (!type.IsInterface && typeof(GenConfig).IsAssignableFrom(type))
@@ -1304,12 +1303,12 @@ namespace XLua
                         var cfg = Activator.CreateInstance(type) as GenConfig;
                         if (cfg.PreferIndexerList != null)
                         {
-                            preferIndexerTypes.AddRange(cfg.PreferIndexerList);
+                            prefer_indexer_types.AddRange(cfg.PreferIndexerList);
                         }
                     }
                     else if (type.IsDefined(typeof(PreferIndexerAttribute), false))
                     {
-                        preferIndexerTypes.Add(type);
+                        prefer_indexer_types.Add(type);
                     }
 
                     if (!type.IsAbstract || !type.IsSealed) continue;
@@ -1320,7 +1319,7 @@ namespace XLua
                         var field = fields[i];
                         if (field.IsDefined(typeof(PreferIndexerAttribute), false) && (typeof(IEnumerable<Type>)).IsAssignableFrom(field.FieldType))
                         {
-                            preferIndexerTypes.AddRange(field.GetValue(null) as IEnumerable<Type>);
+                            prefer_indexer_types.AddRange(field.GetValue(null) as IEnumerable<Type>);
                         }
                     }
 
@@ -1330,13 +1329,13 @@ namespace XLua
                         var prop = props[i];
                         if (prop.IsDefined(typeof(PreferIndexerAttribute), false) && (typeof(IEnumerable<Type>)).IsAssignableFrom(prop.PropertyType))
                         {
-                            preferIndexerTypes.AddRange(prop.GetValue(null, null) as IEnumerable<Type>);
+                            prefer_indexer_types.AddRange(prop.GetValue(null, null) as IEnumerable<Type>);
                         }
                     }
                 }
             }
 
-            return preferIndexerTypes.Contains(theType);
+            return prefer_indexer_types.Contains(theType);
         }
     }
 }

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -235,7 +235,10 @@ namespace XLua
 
         static LuaCSFunction genItemGetter(Type type, PropertyInfo[] props)
         {
-            props = props.Where(prop => prop.GetIndexParameters()[0].ParameterType != typeof(string)).ToArray();
+            if (!isClassPreferIndexer(type))
+            {
+                props = props.Where(prop => prop.GetIndexParameters()[0].ParameterType != typeof(string)).ToArray();
+            }
             if (props.Length == 0)
             {
                 return null;
@@ -1285,6 +1288,55 @@ namespace XLua
             if (!firstParameterConstraint.IsClass)
                 throw new InvalidOperationException();
             return firstParameterConstraint;
+        }
+
+        private static List<Type> preferIndexerTypes = null;
+
+        private static bool isClassPreferIndexer(Type theType)
+        {
+            if (preferIndexerTypes == null)
+            {
+                preferIndexerTypes = new List<Type>();
+                foreach (var type in GetAllTypes())
+                {
+                    if (!type.IsInterface && typeof(GenConfig).IsAssignableFrom(type))
+                    {
+                        var cfg = Activator.CreateInstance(type) as GenConfig;
+                        if (cfg.PreferIndexerList != null)
+                        {
+                            preferIndexerTypes.AddRange(cfg.PreferIndexerList);
+                        }
+                    }
+                    else if (type.IsDefined(typeof(PreferIndexerAttribute), false))
+                    {
+                        preferIndexerTypes.Add(type);
+                    }
+
+                    if (!type.IsAbstract || !type.IsSealed) continue;
+
+                    var fields = type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                    for (int i = 0; i < fields.Length; i++)
+                    {
+                        var field = fields[i];
+                        if (field.IsDefined(typeof(PreferIndexerAttribute), false) && (typeof(IEnumerable<Type>)).IsAssignableFrom(field.FieldType))
+                        {
+                            preferIndexerTypes.AddRange(field.GetValue(null) as IEnumerable<Type>);
+                        }
+                    }
+
+                    var props = type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                    for (int i = 0; i < props.Length; i++)
+                    {
+                        var prop = props[i];
+                        if (prop.IsDefined(typeof(PreferIndexerAttribute), false) && (typeof(IEnumerable<Type>)).IsAssignableFrom(prop.PropertyType))
+                        {
+                            preferIndexerTypes.AddRange(prop.GetValue(null, null) as IEnumerable<Type>);
+                        }
+                    }
+                }
+            }
+
+            return preferIndexerTypes.Contains(theType);
         }
     }
 }


### PR DESCRIPTION
xlua 2.1.6里面变更了一个特性：

> this[string field]操作符重载会影响到继承调用，去掉该特性的支持；

这让在lua试图使用C#的`索引运算符（this[type indexer]）`变得复杂，针对一些类型这个问题尤为突出：

> 例如将一个`Dictionary<string, object>`从C#传递到lua，在lua里面则无法通过`foo.bar`或者`foo['bar']`的语法来访问这个容器里面的内容。

当然这个更改本身也是为了消除二义性：

> lua里的`foo.bar`的语义，有可能：
> 1. 对应着`foo`的一个名叫`bar`的字段（函数、属性、或者成员）;
> 2. 也有可能是以`bar`作为参数，调用对象`foo`的索引运算符方法。

添加`[PreferIndexer]`标记的目的在于：

1. 用户可以自行对类型进行标记，被标记的类型：xlua将支持这个类型的索引运算符，使用`foo.bar`的语法会优先尝试作用到对象的索引运算符方法，如果没有找到则作用到对象的字段上面；
2. 如果不进行标记，将保留现有版本（2.1.6）的行为：xlua将会忽略这个类型的索引运算符，所有`foo.bar`的语法都会直接作用到对象的字段上面。

用法：

可编辑源码类型：

    [PreferIndexer]
    public class MyClass
    {
        public object this[string key]
        {
            get { ... }
            set { ... }
        }
    }

不可编辑源码类型：

    // 在任意类型中添加静态字段
    [PreferIndexer]
    public static List<Type> PreferIndexerList = new List<Type>() {
        typeof(Dictionary<string, object>)
    };