### PR TITLE
修正：如果在Unity中安装了WebGL.Extensions的情况下，XLua无法正常收集所有类型信息

### DIFF
--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -98,7 +98,7 @@ namespace XLua
         {
             return from assembly in AppDomain.CurrentDomain.GetAssemblies()
 #if UNITY_EDITOR || XLUA_GENERAL
-                                          where !(assembly.ManifestModule is System.Reflection.Emit.ModuleBuilder)
+                                          where !(assembly.ManifestModule is System.Reflection.Emit.ModuleBuilder) && assembly.GetName().Name != "UnityEditor.WebGL.Extensions"
 #endif
                                           from type in assembly.GetTypes()
                                           where exclude_generic_definition ? !type.IsGenericTypeDefinition() : true


### PR DESCRIPTION
在安装了`WebGL.Extensions`的情况下，XLua的方法`Utils.GetAllTypes`将会在`assembly.GetTypes()`的时候出现异常：

    ReflectionTypeLoadException: The classes in the module cannot be loaded.

考虑到XLua可能不会用的这个扩展的功能，因此在遍历assembly的时候将其排除。