### PR TITLE
允许用户通过ANDROID_NDK环境变量设置NDK路径

### DIFF
--- a/build/make_android_lua53.sh
+++ b/build/make_android_lua53.sh
@@ -1,4 +1,6 @@
-export ANDROID_NDK=~/android-ndk-r10e
+if [ -z "$ANDROID_NDK" ]; then
+    export ANDROID_NDK=~/android-ndk-r10e
+fi
 
 mkdir -p build_v7a && cd build_v7a
 cmake -DANDROID_ABI=armeabi-v7a -DCMAKE_TOOLCHAIN_FILE=../cmake/android.toolchain.cmake -DANDROID_TOOLCHAIN_NAME=arm-linux-androideabi-clang3.6 -DANDROID_NATIVE_API_LEVEL=android-9 ../

--- a/build/make_android_luajit.sh
+++ b/build/make_android_luajit.sh
@@ -1,4 +1,7 @@
-export ANDROID_NDK=~/android-ndk-r10e
+if [ -z "$ANDROID_NDK" ]; then
+    export ANDROID_NDK=~/android-ndk-r10e
+fi
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SRCDIR=$DIR/luajit-2.1.0b2
 NDK=~/android-ndk-r10e


### PR DESCRIPTION
允许用户通过ANDROID_NDK环境变量设置NDK路径，例如：

    export ANDROID_NDK=/usr/local/android-ndk-r10e
    ./make_android_lua53.sh
