### PR TITLE
Move delegate leak check blow lua vm close

### DIFF
--- a/Assets/XLua/Src/LuaEnv.cs
+++ b/Assets/XLua/Src/LuaEnv.cs
@@ -382,12 +382,12 @@ namespace XLua
                 if (disposed) return;
                 Tick();
 
+                LuaAPI.lua_close(L);
+
                 if (!translator.AllDelegateBridgeReleased())
                 {
                     throw new InvalidOperationException("try to dispose a LuaEnv with C# callback!");
                 }
-
-                LuaAPI.lua_close(L);
 
                 ObjectTranslatorPool.Instance.Remove(L);
                 translator = null;


### PR DESCRIPTION
将 C# 使用 Lua 的 delegation 检查放到了 Lua VM 关闭的语句之下，因为我们在很多地方使用了 lua 对象的 GC 方法来清理 delegation，例如：

```lua
setmetatable(_gcobj, {
	__gc = function()
		_comp:ClearHandlers()
		_go = nil
	end
})
```

不知道这样修改是否合适。