### PR TITLE
修正：WWW.threadPriority在WebGL下不可用，加入导出黑名单

### DIFF
--- a/Assets/XLua/Examples/ExampleGenConfig.cs
+++ b/Assets/XLua/Examples/ExampleGenConfig.cs
@@ -62,6 +62,9 @@ public static class ExampleGenConfig
     [BlackList]
     public static List<List<string>> BlackList = new List<List<string>>()  {
                 new List<string>(){"UnityEngine.WWW", "movie"},
+    #if UNITY_WEBGL
+                new List<string>(){"UnityEngine.WWW", "threadPriority"},
+    #endif
                 new List<string>(){"UnityEngine.Texture2D", "alphaIsTransparency"},
                 new List<string>(){"UnityEngine.Security", "GetChainOfTrustValue"},
                 new List<string>(){"UnityEngine.CanvasRenderer", "onRequestRebuild"},


### PR DESCRIPTION
测试环境：Unity5.6.1f3