### PR TITLE
修复几个在UWP下编译不过的问题

### DIFF
--- a/Assets/XLua/Src/ObjectTranslator.cs
+++ b/Assets/XLua/Src/ObjectTranslator.cs
@@ -355,15 +355,19 @@ namespace XLua
             {
                 return null;
             }
-            
+
             // get by parameters
             MethodInfo delegateMethod = delegateType.GetMethod("Invoke");
             var methods = bridge.GetType().GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            for(int i = 0; i < methods.Length; i++)
+            for (int i = 0; i < methods.Length; i++)
             {
                 if (!methods[i].IsConstructor && Utils.IsParamsMatch(delegateMethod, methods[i]))
                 {
+#if UNITY_EDITOR || XLUA_GENERAL
                     return Delegate.CreateDelegate(delegateType, bridge, methods[i]);
+#else
+                    return methods[i].CreateDelegate(delegateType, bridge);
+#endif
                 }
             }
 

--- a/Assets/XLua/Src/TypeExtensions.cs
+++ b/Assets/XLua/Src/TypeExtensions.cs
@@ -113,5 +113,22 @@ namespace XLua
         }
 #endif
 
+        public static bool IsNestedPublic(this Type type)
+        {
+#if !UNITY_WSA || UNITY_EDITOR
+            return type.IsNestedPublic;
+#else
+            return type.GetTypeInfo().IsNestedPublic;
+#endif        
+        }
+
+        public static bool IsPublic(this Type type)
+        {
+#if !UNITY_WSA || UNITY_EDITOR
+            return type.IsPublic;
+#else
+            return type.GetTypeInfo().IsPublic;
+#endif        
+        }
     }
 }

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -1584,10 +1584,10 @@ namespace XLua
         {
             if (type.IsNested)
             {
-                if (!type.IsNestedPublic) return false;
+                if (!type.IsNestedPublic()) return false;
                 return IsPublic(type.DeclaringType);
             }
-            return type.IsPublic;
+            return type.IsPublic();
         }
     }
 }


### PR DESCRIPTION
Changes:

1. Add IsNestedPublic and IsPublic as extension methods of Type
2. Using MethodInfo.CreateDelegate instead Delegate.CreateDelegate for UWP