### PR TITLE
为LuaTable增加接口CopyTo，用于跨LuaState的LuaTable拷贝

### DIFF
--- a/Assets/XLua/Src/LuaDLL.cs
+++ b/Assets/XLua/Src/LuaDLL.cs
@@ -568,5 +568,8 @@ namespace XLua.LuaDLL
             xlua_set_csharp_wrapper_caller(Marshal.GetFunctionPointerForDelegate(wrapper_caller));
         }
 #endif
+
+        [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern int xlua_copy_table(IntPtr L_src, IntPtr L_dst);
     }
 }

--- a/Assets/XLua/Src/LuaTable.cs
+++ b/Assets/XLua/Src/LuaTable.cs
@@ -390,9 +390,9 @@ namespace XLua
                 var oldTop_dst = LuaAPI.lua_gettop(L_dst);
 
                 luaEnv.translator.Push(L_src, this);
-                if (LuaAPI.xlua_copy_table(L_src, dstEnv.L) != 0)
+                if (LuaAPI.xlua_copy_table(L_src, L_dst) != 0)
                 {                
-                    dstEnv.translator.Get(dstEnv.L, -1, out result);
+                    dstEnv.translator.Get(L_dst, -1, out result);
                 }
 
                 LuaAPI.lua_settop(L_src, oldTop_src);

--- a/Assets/XLua/Src/LuaTable.cs
+++ b/Assets/XLua/Src/LuaTable.cs
@@ -374,5 +374,34 @@ namespace XLua
         {
             return "table :" + luaReference;
         }
+
+        public LuaTable CopyTo(LuaEnv dstEnv)
+        {
+#if THREAD_SAFE || HOTFIX_ENABLE
+            lock (luaEnv.luaEnvLock)
+            lock (dstEnv.luaEnvLock)
+            {
+#endif
+                LuaTable result = null;
+                var L_src = luaEnv.L;
+                var L_dst = dstEnv.L;
+
+                var oldTop_src = LuaAPI.lua_gettop(L_src);
+                var oldTop_dst = LuaAPI.lua_gettop(L_dst);
+
+                luaEnv.translator.Push(L_src, this);
+                if (LuaAPI.xlua_copy_table(L_src, dstEnv.L) != 0)
+                {                
+                    dstEnv.translator.Get(dstEnv.L, -1, out result);
+                }
+
+                LuaAPI.lua_settop(L_src, oldTop_src);
+                LuaAPI.lua_settop(L_dst, oldTop_dst);
+                
+                return result;
+#if THREAD_SAFE || HOTFIX_ENABLE
+            }
+#endif
+        }
     }
 }


### PR DESCRIPTION
在多个LuaState之间复制Table，例如：

```csharp
var envSrc = new LuaEnv();
var envDst = new LuaEnv();

var tableSrc = envSrc.NewTable();
table.Set(1, 1);
table.Set("a", "a");
var tableDst = tableSrc.CopyTo(envDst);
```

限制：

* 只会拷贝原Table中的Key类型为Number和String的元素
* 只会拷贝原Table中的Value类型为Number、String、Boolean、Table的元素
* 可以支持嵌套Table拷贝，但未做循环依赖检查