### PR TITLE
将LuaEnv中的luaLock修改为非静态成员，避免在多线程多LuaEnv种出现死锁

### DIFF
--- a/Assets/XLua/Src/LuaEnv.cs
+++ b/Assets/XLua/Src/LuaEnv.cs
@@ -46,7 +46,7 @@ namespace XLua
         internal int errorFuncRef = -1;
 
 #if THREAD_SAFE || HOTFIX_ENABLE
-        internal static object luaLock = new object();
+        internal /*static*/ object luaLock = new object();
 
         internal object luaEnvLock
         {


### PR DESCRIPTION
同时对ObjectTranslatorPool的Add/Find/Remove方法在开启THREAD_SAFE之后进行加锁。

另外有个问题尚未确认，即：在做了这些修改之后在C#层不会因多线程出现什么问题，但是在长时间的多线程运行模式下Lua虚拟机内部会有几率出现数据错乱。疑似因为原版Lua的native没有实现线程安全（[参考1](http://www.cnblogs.com/ghost240/p/3526185.html)，[参考2](https://stackoverflow.com/questions/3010974/purpose-of-lua-lock-and-lua-unlock?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa)），也许需要结合pthread在编译一份native试试看。