### PR TITLE
支持在类型成员上直接使用LuaCallCSharpAttribute

### DIFF
--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -1272,10 +1272,10 @@ namespace CSObjectWrapEditor
 
         static void MergeCfg(MemberInfo test, Type cfg_type, Func<object> get_cfg)
         {
-            if (test.IsDefined(typeof(LuaCallCSharpAttribute), false))
+            if (test.IsDefined(typeof(LuaCallCSharpAttribute), false) || cfg_type.GetMembers().Any(m => m.IsDefined(typeof(LuaCallCSharpAttribute), false)))
             {
                 object[] ccla = test.GetCustomAttributes(typeof(LuaCallCSharpAttribute), false);
-                AddToList(LuaCallCSharp, get_cfg, ccla[0]);
+                AddToList(LuaCallCSharp, get_cfg, ccla.Length > 0 ? ccla[0] : null);
 #pragma warning disable 618
                 if (ccla.Length == 1 && (((ccla[0] as LuaCallCSharpAttribute).Flag & GenFlag.GCOptimize) != 0))
 #pragma warning restore 618
@@ -1379,7 +1379,7 @@ namespace CSObjectWrapEditor
 #endif
             foreach (var t in check_types)
             {
-                MergeCfg(t, null, () => t);
+                MergeCfg(t, t, () => t);
 
                 if (!t.IsAbstract || !t.IsSealed) continue;
 


### PR DESCRIPTION
在某个类型只希望导出少数成员时，只需要在这些成员上标记LuaCallCSharp；而不是将类型标记为LuaCallCSharp，再依次将不需要导出的成员标记为BlackList;
```
public class AppEntry {
    [LuaCallCSharp]
    public ManagerA { get; private set; }
    
    //...
    //其他不需要导出的方法等
    //...
}
```