### PR TITLE
在Editor中运行时，使 lua 调试器获得文件绝对路径

### DIFF
--- a/Assets/XLua/Src/StaticLuaCallbacks.cs
+++ b/Assets/XLua/Src/StaticLuaCallbacks.cs
@@ -689,11 +689,11 @@ namespace XLua
 #if LUA_DEBUG
                     //get asset's absolute path
                     string assetPath = UnityEditor.AssetDatabase.GetAssetPath(file);
-					if (assetPath != ""){
-						//find out asset path, remove assetPath's first "Asset/"
-						int idx = assetPath.IndexOf("/");
+                    if (assetPath != ""){
+                        //find out asset path, remove assetPath's first "Asset/"
+                        int idx = assetPath.IndexOf("/");
                         if(idx > 0){
-							filename = UnityEngine.Application.dataPath + assetPath.Substring(idx);
+                            filename = UnityEngine.Application.dataPath + assetPath.Substring(idx);
                         }
                     }
 #endif

--- a/Assets/XLua/Src/StaticLuaCallbacks.cs
+++ b/Assets/XLua/Src/StaticLuaCallbacks.cs
@@ -686,7 +686,7 @@ namespace XLua
                 }
                 else
                 {
-#if LUA_DEBUG
+#if LUA_DEBUG && UNITY_EDITOR
                     //get asset's absolute path
                     string assetPath = UnityEditor.AssetDatabase.GetAssetPath(file);
                     if (assetPath != ""){

--- a/Assets/XLua/Src/StaticLuaCallbacks.cs
+++ b/Assets/XLua/Src/StaticLuaCallbacks.cs
@@ -6,6 +6,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
 */
 
+//#define LUA_DEBUG
+
 #if USE_UNI_LUA
 using LuaAPI = UniLua.Lua;
 using RealStatePtr = UniLua.ILuaState;
@@ -684,6 +686,17 @@ namespace XLua
                 }
                 else
                 {
+#if LUA_DEBUG
+                    //get asset's absolute path
+                    string assetPath = UnityEditor.AssetDatabase.GetAssetPath(file);
+					if (assetPath != ""){
+						//find out asset path, remove assetPath's first "Asset/"
+						int idx = assetPath.IndexOf("/");
+                        if(idx > 0){
+							filename = UnityEngine.Application.dataPath + assetPath.Substring(idx);
+                        }
+                    }
+#endif
                     if (LuaAPI.xluaL_loadbuffer(L, file.bytes, file.bytes.Length, "@" + filename) != 0)
                     {
                         return LuaAPI.luaL_error(L, String.Format("error loading module {0} from resource, {1}",
@@ -737,7 +750,11 @@ namespace XLua
                     var bytes = File.ReadAllBytes(filepath);
 
                     UnityEngine.Debug.LogWarning("load lua file from StreamingAssets is obsolete, filename:" + filename);
+#if LUA_DEBUG
+                    if (LuaAPI.xluaL_loadbuffer(L, bytes, bytes.Length, "@" + filepath) != 0)
+#else                    
                     if (LuaAPI.xluaL_loadbuffer(L, bytes, bytes.Length, "@" + filename) != 0)
+#endif                    
                     {
                         return LuaAPI.luaL_error(L, String.Format("error loading module {0} from streamingAssetsPath, {1}",
                             LuaAPI.lua_tostring(L, 1), LuaAPI.lua_tostring(L, -1)));


### PR DESCRIPTION
目的：在lua调试时调用debug.traceback和debug.getinfo时能获得文件绝对路径
修改：增加了LUA_DEBUG宏。当在宏启用时，LoadFromResource 和 LoadFromStreamingAssetsPath 中通过xluaL_loadbuffer 加载文件传入绝对路径。
使用方法：打开StaticLuaCallbacks.cs头部的LUA_DEBUG宏，在Editor中运行时即可