### PR TITLE
osx平台不再支持32bit版本构建

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -148,7 +148,7 @@ if (APPLE)
         )
 		set_xcode_property (xlua IPHONEOS_DEPLOYMENT_TARGET "7.0")
     else ()
-        set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD_32_64_BIT)")
+        set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD_64_BIT)")
         add_library(xlua MODULE
             ${LUA_CORE}
             ${LUA_LIB}


### PR DESCRIPTION
xcode 10已经不在支持32位macos平台架构，从CMakeFileLists.txt去除该平台