### PR TITLE
C#中的UTF8字符串可以直接push给lua，无需经过到byte[]的转换，减少不必要的GC Alloc。

### DIFF
--- a/Assets/XLua/Src/LuaDLL.cs
+++ b/Assets/XLua/Src/LuaDLL.cs
@@ -296,26 +296,15 @@ namespace XLua.LuaDLL
             }
             else
             {
-#if !THREAD_SAFE && !HOTFIX_ENABLE
-                if (Encoding.UTF8.GetByteCount(str) > InternalGlobals.strBuff.Length)
-                {
-                    byte[] bytes = Encoding.UTF8.GetBytes(str);
-                    xlua_pushlstring(L, bytes, bytes.Length);
-                }
-                else
-                {
-                    int bytes_len = Encoding.UTF8.GetBytes(str, 0, str.Length, InternalGlobals.strBuff, 0);
-                    xlua_pushlstring(L, InternalGlobals.strBuff, bytes_len);
-                }
-#else
-                var bytes = Encoding.UTF8.GetBytes(str);
-                xlua_pushlstring(L, bytes, bytes.Length);
-#endif
+                xlua_pushstring(L, str);
             }
         }
 
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern void xlua_pushlstring(IntPtr L, byte[] str, int size);
+        
+        [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void xlua_pushstring(IntPtr L, string str);
 
         public static void xlua_pushasciistring(IntPtr L, string str) // for inner use only
         {
@@ -325,19 +314,7 @@ namespace XLua.LuaDLL
             }
             else
             {
-#if !THREAD_SAFE && !HOTFIX_ENABLE
-                int str_len = str.Length;
-                if (InternalGlobals.strBuff.Length < str_len)
-                {
-                    InternalGlobals.strBuff = new byte[str_len];
-                }
-
-                int bytes_len = Encoding.UTF8.GetBytes(str, 0, str_len, InternalGlobals.strBuff, 0);
-                xlua_pushlstring(L, InternalGlobals.strBuff, bytes_len);
-#else
-                var bytes = Encoding.UTF8.GetBytes(str);
-                xlua_pushlstring(L, bytes, bytes.Length);
-#endif
+                xlua_pushstring(L, str);
             }
         }
 

--- a/build/xlua.c
+++ b/build/xlua.c
@@ -201,10 +201,6 @@ LUA_API void xlua_pushlstring (lua_State *L, const char *s, int len) {
 	lua_pushlstring(L, s, len);
 }
 
-LUA_API void xlua_pushstring (lua_State *L, const char *s) {
-	lua_pushstring(L, s);
-}
-
 LUALIB_API int xluaL_loadbuffer (lua_State *L, const char *buff, int size,
                                 const char *name) {
 	return luaL_loadbuffer(L, buff, size, name);

--- a/build/xlua.c
+++ b/build/xlua.c
@@ -201,6 +201,10 @@ LUA_API void xlua_pushlstring (lua_State *L, const char *s, int len) {
 	lua_pushlstring(L, s, len);
 }
 
+LUA_API void xlua_pushstring (lua_State *L, const char *s) {
+	lua_pushstring(L, s);
+}
+
 LUALIB_API int xluaL_loadbuffer (lua_State *L, const char *buff, int size,
                                 const char *name) {
 	return luaL_loadbuffer(L, buff, size, name);


### PR DESCRIPTION
除了终结符\0之外，UTF-8中的任何其他字符均不包含值为0的字节。C#中的UTF8字符串可以直接push给lua。
参考资料：https://stackoverflow.com/a/6907327/2289969