### PR TITLE
当Dispose被调用时由于先Remove了ObjectTranslator, 故在lua_close的时候调用LuaGC时会发出异常

### DIFF
--- a/Assets/XLua/Src/StaticLuaCallbacks.cs
+++ b/Assets/XLua/Src/StaticLuaCallbacks.cs
@@ -164,7 +164,10 @@ namespace XLua
                 if (udata != -1)
                 {
                     ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
-                    translator.collectObject(udata);
+                    if ( translator )
+                    {
+                        translator.collectObject(udata);
+                    }
                 }
                 return 0;
             }


### PR DESCRIPTION
当Dispose被调用时，由于先Remove了ObjectTranslator, 所以在lua_close的时候调用LuaGC时会抛出signal 11， 但是在android上由于mono 处理了signal并不会导致程序奔溃，但是当自己处理sig_handler的时候就会存在问题.