### PR TITLE
- add BlackList feature for enums

### DIFF
--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -618,6 +618,10 @@ namespace CSObjectWrapEditor
             
             GenOne(null, (type, type_info) =>
             {
+                var type2fields = luaenv.NewTable();
+                foreach(var _type in types)
+                    type2fields.Set(_type, _type.GetFields(BindingFlags.Public | BindingFlags.Static).Where(x => !isMemberInBlackList(x)).ToArray());
+                type_info.Set("type2fields", type2fields);
                 type_info.Set("types", types.ToList());
             }, templateRef.LuaEnumWrap, textWriter);
 

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
@@ -19,7 +19,7 @@ namespace XLua.CSObjectWrap
 {
     using Utils = XLua.Utils;
     <%ForEachCsList(types, function(type)
-	local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
 	%>
     public class <%=CSVariableName(type)%>Wrap
     {

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
@@ -20,7 +20,7 @@ namespace XLua
 	public partial class ObjectTranslator
     {
     <%ForEachCsList(types, function(type)
-	local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
 	local v_type_name = CSVariableName(type)
 	%>
 		public void __Register<%=v_type_name%>(RealStatePtr L)


### PR DESCRIPTION
We have a huge c# enum file in our project, which may hold 1M memory, and the enums seldom used in lua.
So we decide to blacklist all field of this enum, and modified source to support this feature.