### PR TITLE
fix: more rubost XLuaHotfixInject path combination

### DIFF
--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -1621,7 +1621,7 @@ namespace XLua
             var mono_path = Path.Combine(Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName),
                 "Data/MonoBleedingEdge/bin/mono.exe");
 #endif
-            var inject_tool_path = "./Tools/XLuaHotfixInject.exe";
+            var inject_tool_path = Path.Combine(Application.dataPath, "Tools/XLuaHotfixInject.exe");
             if (!File.Exists(inject_tool_path))
             {
                 UnityEngine.Debug.LogError("please install the Tools");


### PR DESCRIPTION
在mac osx中File.Exist函数对相对路径不友好.