### PR TITLE
这里有可能是通过反射得到未设置泛型的类型导致lua脚本报错生成代码失败

### DIFF
--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -932,6 +932,7 @@ namespace CSObjectWrapEditor
             }
 
             var delegates_groups = types.Select(delegate_type => makeMethodInfoSimulation(delegate_type.GetMethod("Invoke")))
+                .Where(d => d.DeclaringType.FullName != null)
                 .Concat(hotfxDelegates)
                 .GroupBy(d => d, comparer).Select((group) => new { Key = group.Key, Value = group.ToList()});
             GenOne(typeof(DelegateBridge), (type, type_info) =>


### PR DESCRIPTION
执行XLua/Generate Code
如果反射得到一个未设置泛型类型的方法那么类型的FullName是null
会导致lua那边_CsFullTypeName方法里面local name = t.FullName:gsub("&", ""):gsub("%+", ".") 这一句代码报错
谢谢.