### PR TITLE
bugfix:修复Hotfix inject创建Delegate时无法正确复制out参数属性的问题

### DIFF
--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -406,6 +406,23 @@ namespace XLua
             }
         }
 
+        private static ParameterDefinition CloneParameterDef(ParameterDefinition defCopy, TypeReference refCopy)
+        {
+            ParameterDefinition tempParDef = null;
+            if (defCopy.IsOut)
+            {
+                tempParDef = new ParameterDefinition(defCopy.Name, Mono.Cecil.ParameterAttributes.Out, refCopy) { IsOut = true};
+            }
+            else if (defCopy.IsIn)
+            {
+                tempParDef = new ParameterDefinition(defCopy.Name, Mono.Cecil.ParameterAttributes.In, refCopy) { IsIn = true};
+            }
+            else
+            {
+                tempParDef = new ParameterDefinition(defCopy.Name, Mono.Cecil.ParameterAttributes.None, refCopy);
+            }
+            return tempParDef;
+        }
         MethodDefinition createDelegateFor(MethodDefinition method, AssemblyDefinition assembly, string delegateName, bool ignoreValueType)
         {
             var voidType = assembly.MainModule.TypeSystem.Void;
@@ -443,7 +460,7 @@ namespace XLua
             }
             for (int i = 0; i < argTypes.Count; i++)
             {
-                beginInvoke.Parameters.Add(new ParameterDefinition(method.Parameters[i].Name, (method.Parameters[i].IsOut ? Mono.Cecil.ParameterAttributes.Out : Mono.Cecil.ParameterAttributes.None), argTypes[i]));
+                beginInvoke.Parameters.Add(CloneParameterDef(method.Parameters[i], argTypes[i]));
             }
             beginInvoke.Parameters.Add(new ParameterDefinition("callback", Mono.Cecil.ParameterAttributes.None, asyncCallbackType));
             beginInvoke.Parameters.Add(new ParameterDefinition("object", Mono.Cecil.ParameterAttributes.None, objectType));
@@ -467,9 +484,9 @@ namespace XLua
             {
                 invoke.Parameters.Add(new ParameterDefinition(self));
             }
-            foreach (var argType in argTypes)
+            for (int i = 0; i < argTypes.Count; i++)
             {
-                invoke.Parameters.Add(new ParameterDefinition(argType));
+                invoke.Parameters.Add(CloneParameterDef(method.Parameters[i], argTypes[i]));
             }
             invoke.ImplAttributes = Mono.Cecil.MethodImplAttributes.Runtime;
             delegateDef.Methods.Add(invoke);


### PR DESCRIPTION
![xlua_bugfix](https://user-images.githubusercontent.com/5344868/61863562-6624e480-af02-11e9-9789-fc4ee953c685.png)
inject dll生成的delegate参数的同原方法不一致，原方法的out参数，会被当做ref参数，导制无法正确匹配参数