### PR TITLE
fix error display when StaticLuaCallbacks::ImportType throws

### DIFF
--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -1368,8 +1368,9 @@ namespace XLua
 				LuaAPI.xlua_pushasciistring(L, path[i]);
 				if (0 != LuaAPI.xlua_pgettable(L, -2))
 				{
+					var err = LuaAPI.lua_tostring(L, -1);
 					LuaAPI.lua_settop(L, oldTop);
-					throw new Exception("SetCSTable for [" + type + "] error: " + LuaAPI.lua_tostring(L, -1));
+					throw new Exception("SetCSTable for [" + type + "] error: " + err);
 				}
 				if (LuaAPI.lua_isnil(L, -1))
 				{


### PR DESCRIPTION
We added profiler code in StaticLuaCallbacks::ImportType function, but our code throws exception in some circumstances, when it happens, we saw xlua->generate command will print: "SetCSTable for "System.Type" error:", but no specific error displayed.

So it comes this PR.