### PR TITLE
* fix LazyReflectionCall with overloaded methods

### DIFF
--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -580,17 +580,17 @@ namespace XLua
 			}
 		}
 
-		public static void loadUpvalue(RealStatePtr L, Type type, string metafunc, int num)
+		public static void loadUpvalue(RealStatePtr L, Type type, string metafunc, int index)
 		{
 			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
-			LuaAPI.xlua_pushasciistring(L, metafunc); // "metafunc"
-			LuaAPI.lua_rawget(L, LuaIndexes.LUA_REGISTRYINDEX); // {metafunc}
-			translator.Push(L, type); // {metafunc} c:type
-			LuaAPI.lua_rawget(L, -2); // {metafunc} function
-			LuaAPI.lua_remove(L, -2); // function
-			for (int i = 1; i <= num; i++)
+			LuaAPI.xlua_pushasciistring(L, metafunc);
+			LuaAPI.lua_rawget(L, LuaIndexes.LUA_REGISTRYINDEX);
+			translator.Push(L, type);
+			LuaAPI.lua_rawget(L, -2);
+			LuaAPI.lua_remove(L, -2);
+			for (int i = 1; i <= index; i++)
 			{
-				LuaAPI.lua_getupvalue(L, -i, i); // function upvalue
+				LuaAPI.lua_getupvalue(L, -i, i);
 				if (LuaAPI.lua_isnil(L, -1))
 				{
 					LuaAPI.lua_pop(L, 1);
@@ -599,11 +599,10 @@ namespace XLua
 					LuaAPI.lua_setupvalue(L, -i - 2, i);
 				}
 			}
-			for (int i = 0; i < num; i++)
+			for (int i = 0; i < index; i++)
 			{
-				LuaAPI.lua_remove(L, -num - 1);
+				LuaAPI.lua_remove(L, -2);
 			}
-			// upvalue
 		}
 
         public static void RegisterEnumType(RealStatePtr L, Type type)
@@ -640,7 +639,8 @@ namespace XLua
 
 			loadUpvalue(L, type, LuaIndexsFieldName, 2);
 			int obj_getter = LuaAPI.lua_gettop(L);
-			int obj_field = obj_getter - 1;
+			loadUpvalue(L, type, LuaIndexsFieldName, 1);
+			int obj_field = LuaAPI.lua_gettop(L);
 
 			loadUpvalue(L, type, LuaNewIndexsFieldName, 1);
 			int obj_setter = LuaAPI.lua_gettop(L);
@@ -737,7 +737,6 @@ namespace XLua
 							if (memberType == LazyMemberTypes.FieldGet)
 							{
 								loadUpvalue(L, type, LuaIndexsFieldName, 2);
-								LuaAPI.lua_remove(L, -2);
 							}
 							else
 							{
@@ -771,7 +770,6 @@ namespace XLua
 							if (memberType == LazyMemberTypes.PropertyGet)
 							{
 								loadUpvalue(L, type, LuaIndexsFieldName, 2);
-								LuaAPI.lua_remove(L, -2);
 							}
 							else
 							{

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -583,13 +583,14 @@ namespace XLua
 		public static void loadUpvalue(RealStatePtr L, Type type, string metafunc, int num)
 		{
 			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
-			LuaAPI.xlua_pushasciistring(L, metafunc);
-			LuaAPI.lua_rawget(L, LuaIndexes.LUA_REGISTRYINDEX);
-			translator.Push(L, type);
-			LuaAPI.lua_rawget(L, -2);
+			LuaAPI.xlua_pushasciistring(L, metafunc); // "metafunc"
+			LuaAPI.lua_rawget(L, LuaIndexes.LUA_REGISTRYINDEX); // {metafunc}
+			translator.Push(L, type); // {metafunc} c:type
+			LuaAPI.lua_rawget(L, -2); // {metafunc} function
+			LuaAPI.lua_remove(L, -2); // function
 			for (int i = 1; i <= num; i++)
 			{
-				LuaAPI.lua_getupvalue(L, -i, i);
+				LuaAPI.lua_getupvalue(L, -i, i); // function upvalue
 				if (LuaAPI.lua_isnil(L, -1))
 				{
 					LuaAPI.lua_pop(L, 1);
@@ -602,6 +603,7 @@ namespace XLua
 			{
 				LuaAPI.lua_remove(L, -num - 1);
 			}
+			// upvalue
 		}
 
         public static void RegisterEnumType(RealStatePtr L, Type type)


### PR DESCRIPTION
we have three functions:
        public bool IsHaveHero(UInt32 id, bool isIncludeTimeLimited)
        {        }
        public bool IsHaveHero(UInt32 id, RoleInfoOwnState state)
        {    // the second parameter is an enum
        }
        public bool IsHaveHero(UInt32 heroId)
        {        }
we configured this function as [DoNotGen].
when call the function role:IsHaveHero(xx, xxx), in MethodWrap::Call, the stack top is 4(which should be 3)
after further investigation, we found that after loadUpvalue, the stack grows wongly
