### PR TITLE
update ios luajit build shell for xcode10.1

### DIFF
--- a/build/make_ios_luajit.sh
+++ b/build/make_ios_luajit.sh
@@ -22,8 +22,8 @@ fi
 cd luajit-2.1.0b3
 
 XCODEVER=`xcodebuild -version|head -n 1|sed 's/Xcode \([0-9]*\)/\1/g'`
-
-if [ $XCODEVER -lt 10]
+ISOLD_XCODEVER=`echo "$XCODEVER < 10" | bc`
+if [ ISOLD_XCODEVER == 1 ]
 then
     make clean
     ISDKF="-arch armv7 -isysroot $ISDK/SDKs/$ISDKVER -miphoneos-version-min=7.0"
@@ -40,7 +40,12 @@ ISDKF="-arch arm64 -isysroot $ISDK/SDKs/$ISDKVER -miphoneos-version-min=7.0"
 make HOST_CC="gcc -std=c99" TARGET_FLAGS="$ISDKF" TARGET=arm64 TARGET_SYS=iOS LUAJIT_A=libxlua64.a
 
 cd src
-lipo libxluav7.a -create libxluav7s.a libxlua64.a -output libluajit.a
+if [ ISOLD_XCODEVER == 1 ]
+then
+    lipo libxluav7.a -create libxluav7s.a libxlua64.a -output libluajit.a
+else
+    mv libxlua64.a libluajit.a
+fi
 cd ../..
 
 mkdir -p build_lj_ios && cd build_lj_ios


### PR DESCRIPTION
Hi.
I updated ios/luajit build script for xcode 10.1

in my case, $XCODEVER is "10.1" and I got 2 errors

* `make_ios_luajit.sh: line 26: [: missing `]'`
* `lipo: can't open input file: libxluav7.a (No such file or directory)`

i updated if lines.

Regards.