### PR TITLE
feat: add UNITY_TVOS

### DIFF
--- a/Assets/XLua/Src/DelegateBridge.cs
+++ b/Assets/XLua/Src/DelegateBridge.cs
@@ -86,7 +86,7 @@ namespace XLua
 
     public static class HotfixDelegateBridge
     {
-#if UNITY_IPHONE && !UNITY_EDITOR
+#if (UNITY_IPHONE || UNITY_TVOS) && !UNITY_EDITOR
         [DllImport("__Internal", CallingConvention = CallingConvention.Cdecl)]
         public static extern bool xlua_get_hotfix_flag(int idx);
 
@@ -117,7 +117,7 @@ namespace XLua
                 DelegateBridge.DelegateBridgeList = newList;
             }
             DelegateBridge.DelegateBridgeList[idx] = val;
-#if UNITY_IPHONE && !UNITY_EDITOR
+#if (UNITY_IPHONE || UNITY_TVOS) && !UNITY_EDITOR
             xlua_set_hotfix_flag(idx, val != null);
 #endif
         }

--- a/Assets/XLua/Src/LuaDLL.cs
+++ b/Assets/XLua/Src/LuaDLL.cs
@@ -33,7 +33,7 @@ namespace XLua.LuaDLL
 
     public partial class Lua
 	{
-#if (UNITY_IPHONE || UNITY_WEBGL || UNITY_SWITCH) && !UNITY_EDITOR
+#if (UNITY_IPHONE || UNITY_TVOS || UNITY_WEBGL || UNITY_SWITCH) && !UNITY_EDITOR
         const string LUADLL = "__Internal";
 #else
         const string LUADLL = "xlua";
@@ -292,7 +292,7 @@ namespace XLua.LuaDLL
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern void lua_pushstring(IntPtr L, string str);
 #else
-        public static void lua_pushstring(IntPtr L, string str) //业务使用
+        public static void lua_pushstring(IntPtr L, string str) //涓氬姟浣跨敤
         {
             if (str == null)
             {
@@ -542,7 +542,7 @@ namespace XLua.LuaDLL
         //[DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         //public static extern void xlua_pushbuffer(IntPtr L, byte[] buff);
 
-        //对于Unity，仅浮点组成的struct较多，这几个api用于优化这类struct
+        //瀵逛簬Unity锛屼粎娴偣缁勬垚鐨剆truct杈冨锛岃繖鍑犱釜api鐢ㄤ簬浼樺寲杩欑被struct
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]
         public static extern bool xlua_pack_float2(IntPtr buff, int offset, float f1, float f2);
         [DllImport(LUADLL, CallingConvention = CallingConvention.Cdecl)]


### PR DESCRIPTION
Dear,

We had to adapt xLua to AppleTV(tvOS).
Added some Preprocessor definition.

Please check and merge it.

https://apps.apple.com/jp/app/id1471596310#?platform=appleTV

This game app was almost made by xLua.
Thanks.
