### PR TITLE
changes for supporting upm

### DIFF
--- a/Assets/XLua/Examples/02_U3DScripting/LuaBehaviour.cs
+++ b/Assets/XLua/Examples/02_U3DScripting/LuaBehaviour.cs
@@ -27,7 +27,7 @@ namespace XLuaTest
         public TextAsset luaScript;
         public Injection[] injections;
 
-        internal static LuaEnv luaEnv = new LuaEnv(); //all lua behaviour shared one luaenv only!
+        internal static LuaEnv luaEnv; //all lua behaviour shared one luaenv only!
         internal static float lastGCTime = 0;
         internal const float GCInterval = 1;//1 second 
 
@@ -39,6 +39,17 @@ namespace XLuaTest
 
         void Awake()
         {
+            var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+            if (prefab)
+            {
+                var go = Instantiate(prefab);
+
+            }
+            else
+            {
+                Debug.LogError("Not generate wraps");
+            }
+            luaEnv = new LuaEnv();
             scriptEnv = luaEnv.NewTable();
 
             // 为每个脚本设置一个独立的环境，可一定程度上防止脚本间全局变量、函数冲突

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -31,11 +31,12 @@ namespace CSObjectWrapEditor
 
         static GeneratorConfig()
         {
-            foreach(var type in (from type in XLua.Utils.GetAllTypes()
-            where type.IsAbstract && type.IsSealed
-            select type))
+            foreach (var type in (from type in XLua.Utils.GetAllTypes()
+                where type.IsAbstract && type.IsSealed
+                select type))
             {
-                foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.Public |
+                                                     BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                 {
                     if (field.FieldType == typeof(string) && field.IsDefined(typeof(GenPathAttribute), false))
                     {
@@ -47,7 +48,8 @@ namespace CSObjectWrapEditor
                     }
                 }
 
-                foreach (var prop in type.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+                foreach (var prop in type.GetProperties(BindingFlags.Static | BindingFlags.Public |
+                                                        BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
                 {
                     if (prop.PropertyType == typeof(string) && prop.IsDefined(typeof(GenPathAttribute), false))
                     {
@@ -77,12 +79,10 @@ namespace CSObjectWrapEditor
 
     public class GenCodeMenuAttribute : Attribute
     {
-
     }
 
     public class GenPathAttribute : Attribute
     {
-
     }
 
     public struct XLuaTemplate
@@ -107,8 +107,14 @@ namespace CSObjectWrapEditor
     public static class Generator
     {
         static LuaEnv luaenv = new LuaEnv();
-        static List<string> OpMethodNames = new List<string>() { "op_Addition", "op_Subtraction", "op_Multiply", "op_Division", "op_Equality", "op_UnaryNegation", "op_LessThan", "op_LessThanOrEqual", "op_Modulus",
-            "op_BitwiseAnd", "op_BitwiseOr", "op_ExclusiveOr", "op_OnesComplement", "op_LeftShift", "op_RightShift"};
+
+        static List<string> OpMethodNames = new List<string>()
+        {
+            "op_Addition", "op_Subtraction", "op_Multiply", "op_Division", "op_Equality", "op_UnaryNegation",
+            "op_LessThan", "op_LessThanOrEqual", "op_Modulus",
+            "op_BitwiseAnd", "op_BitwiseOr", "op_ExclusiveOr", "op_OnesComplement", "op_LeftShift", "op_RightShift"
+        };
+
         private static XLuaTemplates templateRef;
 
         static Generator()
@@ -121,24 +127,26 @@ namespace CSObjectWrapEditor
 #if GEN_CODE_MINIMIZE
                 LuaClassWrap = { name = template_ref.LuaClassWrapGCM.name, text = template_ref.LuaClassWrapGCM.text },
 #else
-                LuaClassWrap = { name = template_ref.LuaClassWrap.name, text = template_ref.LuaClassWrap.text },
+                LuaClassWrap = {name = template_ref.LuaClassWrap.name, text = template_ref.LuaClassWrap.text},
 #endif
-                LuaDelegateBridge = { name = template_ref.LuaDelegateBridge.name, text = template_ref.LuaDelegateBridge.text },
-                LuaDelegateWrap = { name = template_ref.LuaDelegateWrap.name, text = template_ref.LuaDelegateWrap.text },
+                LuaDelegateBridge =
+                    {name = template_ref.LuaDelegateBridge.name, text = template_ref.LuaDelegateBridge.text},
+                LuaDelegateWrap = {name = template_ref.LuaDelegateWrap.name, text = template_ref.LuaDelegateWrap.text},
 #if GEN_CODE_MINIMIZE
                 LuaEnumWrap = { name = template_ref.LuaEnumWrapGCM.name, text = template_ref.LuaEnumWrapGCM.text },
 #else
-                LuaEnumWrap = { name = template_ref.LuaEnumWrap.name, text = template_ref.LuaEnumWrap.text },
+                LuaEnumWrap = {name = template_ref.LuaEnumWrap.name, text = template_ref.LuaEnumWrap.text},
 #endif
-                LuaInterfaceBridge = { name = template_ref.LuaInterfaceBridge.name, text = template_ref.LuaInterfaceBridge.text },
+                LuaInterfaceBridge =
+                    {name = template_ref.LuaInterfaceBridge.name, text = template_ref.LuaInterfaceBridge.text},
 #if GEN_CODE_MINIMIZE
                 LuaRegister = { name = template_ref.LuaRegisterGCM.name, text = template_ref.LuaRegisterGCM.text },
 #else
-                LuaRegister = { name = template_ref.LuaRegister.name, text = template_ref.LuaRegister.text },
+                LuaRegister = {name = template_ref.LuaRegister.name, text = template_ref.LuaRegister.text},
 #endif
-                LuaWrapPusher = { name = template_ref.LuaWrapPusher.name, text = template_ref.LuaWrapPusher.text },
-                PackUnpack = { name = template_ref.PackUnpack.name, text = template_ref.PackUnpack.text },
-                TemplateCommon = { name = template_ref.TemplateCommon.name, text = template_ref.TemplateCommon.text },
+                LuaWrapPusher = {name = template_ref.LuaWrapPusher.name, text = template_ref.LuaWrapPusher.text},
+                PackUnpack = {name = template_ref.PackUnpack.name, text = template_ref.PackUnpack.text},
+                TemplateCommon = {name = template_ref.TemplateCommon.name, text = template_ref.TemplateCommon.text},
             };
 #endif
             luaenv.AddLoader((ref string filepath) =>
@@ -157,7 +165,8 @@ namespace CSObjectWrapEditor
         static bool IsOverride(MethodBase method)
         {
             var m = method as MethodInfo;
-            return m != null && !m.IsConstructor && m.IsVirtual && (m.GetBaseDefinition().DeclaringType != m.DeclaringType);
+            return m != null && !m.IsConstructor && m.IsVirtual &&
+                   (m.GetBaseDefinition().DeclaringType != m.DeclaringType);
         }
 
         static int OverloadCosting(MethodBase mi)
@@ -171,11 +180,12 @@ namespace CSObjectWrapEditor
 
             foreach (var paraminfo in mi.GetParameters())
             {
-                if ((!paraminfo.ParameterType.IsPrimitive ) && (paraminfo.IsIn || !paraminfo.IsOut))
+                if ((!paraminfo.ParameterType.IsPrimitive) && (paraminfo.IsIn || !paraminfo.IsOut))
                 {
                     costing++;
                 }
             }
+
             costing = costing * 10000 + (mi.GetParameters().Length + (mi.IsStatic ? 0 : 1));
             return costing;
         }
@@ -189,15 +199,16 @@ namespace CSObjectWrapEditor
                 var gen_types = LuaCallCSharp;
 
                 type_has_extension_methods = from type in gen_types
-                                             where type.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                                                    .Any(method => isDefined(method, typeof(ExtensionAttribute)))
-                                             select type;
+                    where type.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                        .Any(method => isDefined(method, typeof(ExtensionAttribute)))
+                    select type;
             }
+
             return from type in type_has_extension_methods
-                   where type.IsSealed && !type.IsGenericType && !type.IsNested
-                        from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                        where isSupportedExtensionMethod(method, extendedType)
-                        select method;
+                where type.IsSealed && !type.IsGenericType && !type.IsNested
+                from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                where isSupportedExtensionMethod(method, extendedType)
+                select method;
         }
 
         static bool isSupportedExtensionMethod(MethodBase method, Type extendedType)
@@ -221,11 +232,13 @@ namespace CSObjectWrapEditor
                         bool firstParamMatch = false;
                         foreach (var parameterConstraint in parameterConstraints)
                         {
-                            if (parameterConstraint != typeof(ValueType) && parameterConstraint.IsAssignableFrom(extendedType))
+                            if (parameterConstraint != typeof(ValueType) &&
+                                parameterConstraint.IsAssignableFrom(extendedType))
                             {
                                 firstParamMatch = true;
                             }
                         }
+
                         if (!firstParamMatch) return false;
 
                         hasValidGenericParameter = true;
@@ -239,12 +252,15 @@ namespace CSObjectWrapEditor
                     if (parameterConstraints.Length == 0) return false;
                     foreach (var parameterConstraint in parameterConstraints)
                     {
-                        if (!parameterConstraint.IsClass || (parameterConstraint == typeof(ValueType)) || Generator.hasGenericParameter(parameterConstraint))
+                        if (!parameterConstraint.IsClass || (parameterConstraint == typeof(ValueType)) ||
+                            Generator.hasGenericParameter(parameterConstraint))
                             return false;
                     }
+
                     hasValidGenericParameter = true;
                 }
             }
+
             return hasValidGenericParameter || !method.ContainsGenericParameters;
         }
 
@@ -261,7 +277,9 @@ namespace CSObjectWrapEditor
             var constructor_def_vals = new List<int>();
             if (!type.IsAbstract)
             {
-                foreach (var con in type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase).Cast<MethodBase>()
+                foreach (var con in type
+                    .GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.IgnoreCase)
+                    .Cast<MethodBase>()
                     .Where(constructor => !isMethodInBlackList(constructor) && !isObsolete(constructor)))
                 {
                     int def_count = 0;
@@ -285,12 +303,13 @@ namespace CSObjectWrapEditor
                     }
                 }
             }
+
             parameters.Set("constructors", constructors);
             parameters.Set("constructor_def_vals", constructor_def_vals);
 
             List<string> extension_methods_namespace = new List<string>();
-            var extension_methods = type.IsInterface ? new MethodInfo[0]:GetExtensionMethods(type).ToArray();
-            foreach(var extension_method in extension_methods)
+            var extension_methods = type.IsInterface ? new MethodInfo[0] : GetExtensionMethods(type).ToArray();
+            foreach (var extension_method in extension_methods)
             {
                 if (extension_method.DeclaringType.Namespace != null
                     && extension_method.DeclaringType.Namespace != "System.Collections.Generic"
@@ -299,108 +318,173 @@ namespace CSObjectWrapEditor
                     extension_methods_namespace.Add(extension_method.DeclaringType.Namespace);
                 }
             }
+
             parameters.Set("namespaces", extension_methods_namespace.Distinct().ToList());
 
             List<LazyMemberInfo> lazyMemberInfos = new List<LazyMemberInfo>();
 
             //warnning: filter all method start with "op_"  "add_" "remove_" may  filter some ordinary method
-            parameters.Set("methods", type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                .Where(method => !isDefined(method, typeof (ExtensionAttribute)) || method.GetParameters()[0].ParameterType.IsInterface || method.DeclaringType != type)
-                .Where(method => !method.IsSpecialName 
-                    || (
-                         ((method.Name == "get_Item" && method.GetParameters().Length == 1) || (method.Name == "set_Item" && method.GetParameters().Length == 2)) 
-                         && method.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(string))
-                       )
-                 ) 
+            parameters.Set("methods", type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                            BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+                .Where(method =>
+                    !isDefined(method, typeof(ExtensionAttribute)) ||
+                    method.GetParameters()[0].ParameterType.IsInterface || method.DeclaringType != type)
+                .Where(method => !method.IsSpecialName
+                                 || (
+                                     ((method.Name == "get_Item" && method.GetParameters().Length == 1) ||
+                                      (method.Name == "set_Item" && method.GetParameters().Length == 2))
+                                     && method.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(string))
+                                 )
+                )
                 .Concat(extension_methods)
                 .Where(method => !IsDoNotGen(type, method.Name))
-                .Where(method => !isMethodInBlackList(method) && (!method.IsGenericMethod || extension_methods.Contains(method) || isSupportedGenericMethod(method)) && !isObsolete(method))
-                .GroupBy(method => (method.Name + ((method.IsStatic && (!isDefined(method, typeof (ExtensionAttribute)) || method.GetParameters()[0].ParameterType.IsInterface)) ? "_xlua_st_" : "")), (k, v) =>
-                {
-                    var overloads = new List<MethodBase>();
-                    List<int> def_vals = new List<int>();
-                    bool isOverride = false;
-                    foreach (var overload in v.Cast<MethodBase>().OrderBy(mb => OverloadCosting(mb)))
+                .Where(method =>
+                    !isMethodInBlackList(method) &&
+                    (!method.IsGenericMethod || extension_methods.Contains(method) ||
+                     isSupportedGenericMethod(method)) && !isObsolete(method))
+                .GroupBy(
+                    method => (method.Name +
+                               ((method.IsStatic && (!isDefined(method, typeof(ExtensionAttribute)) ||
+                                                     method.GetParameters()[0].ParameterType.IsInterface))
+                                   ? "_xlua_st_"
+                                   : "")), (k, v) =>
                     {
-                        int def_count = 0;
-                        overloads.Add(overload);
-                        def_vals.Add(def_count);
-
-                        if (!isOverride)
+                        var overloads = new List<MethodBase>();
+                        List<int> def_vals = new List<int>();
+                        bool isOverride = false;
+                        foreach (var overload in v.Cast<MethodBase>().OrderBy(mb => OverloadCosting(mb)))
                         {
-                            isOverride = IsOverride(overload);
+                            int def_count = 0;
+                            overloads.Add(overload);
+                            def_vals.Add(def_count);
+
+                            if (!isOverride)
+                            {
+                                isOverride = IsOverride(overload);
+                            }
+
+                            var ps = overload.GetParameters();
+                            for (int i = ps.Length - 1; i >= 0; i--)
+                            {
+                                if (ps[i].IsOptional ||
+                                    (ps[i].IsDefined(typeof(ParamArrayAttribute), false) && i > 0 &&
+                                     ps[i - 1].IsOptional))
+                                {
+                                    def_count++;
+                                    overloads.Add(overload);
+                                    def_vals.Add(def_count);
+                                }
+                                else
+                                {
+                                    break;
+                                }
+                            }
                         }
 
-                        var ps = overload.GetParameters();
-                        for (int i = ps.Length - 1; i >=0; i--)
+                        return new
                         {
-                            if(ps[i].IsOptional ||
-                            (ps[i].IsDefined(typeof(ParamArrayAttribute), false) && i > 0 && ps[i - 1].IsOptional))
-                            {
-                                def_count++;
-                                overloads.Add(overload);
-                                def_vals.Add(def_count);
-                            }
-                            else
-                            {
-                                break;
-                            }
-                        }
-                    }
+                            Name = k,
+                            IsStatic = overloads[0].IsStatic &&
+                                       (!isDefined(overloads[0], typeof(ExtensionAttribute)) ||
+                                        overloads[0].GetParameters()[0].ParameterType.IsInterface),
+                            Overloads = overloads,
+                            DefaultValues = def_vals
+                        };
+                    }).ToList());
 
-                    return new {
-                        Name = k,
-                        IsStatic = overloads[0].IsStatic && (!isDefined(overloads[0], typeof(ExtensionAttribute)) || overloads[0].GetParameters()[0].ParameterType.IsInterface),
-                        Overloads = overloads,
-                        DefaultValues = def_vals
-                    };
-                }).ToList());
-
-            parameters.Set("getters", type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                
-                .Where(prop => prop.GetIndexParameters().Length == 0 && prop.CanRead && (prop.GetGetMethod() != null)  && prop.Name != "Item" && !isObsolete(prop) && !isObsolete(prop.GetGetMethod()) && !isMemberInBlackList(prop) && !isMemberInBlackList(prop.GetGetMethod())).Select(prop => new { prop.Name, IsStatic = prop.GetGetMethod().IsStatic, ReadOnly = false, Type = prop.PropertyType })
+            parameters.Set("getters", type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                               BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+                .Where(prop => prop.GetIndexParameters().Length == 0 && prop.CanRead && (prop.GetGetMethod() != null) &&
+                               prop.Name != "Item" && !isObsolete(prop) && !isObsolete(prop.GetGetMethod()) &&
+                               !isMemberInBlackList(prop) && !isMemberInBlackList(prop.GetGetMethod())).Select(prop =>
+                    new
+                    {
+                        prop.Name, IsStatic = prop.GetGetMethod().IsStatic, ReadOnly = false, Type = prop.PropertyType
+                    })
                 .Concat(
-                    type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                    .Where(field => !isObsolete(field) && !isMemberInBlackList(field))
-                    .Select(field => new { field.Name, field.IsStatic, ReadOnly = field.IsInitOnly || field.IsLiteral, Type = field.FieldType })
-                ).Where(info => !IsDoNotGen(type, info.Name))/*.Where(getter => !typeof(Delegate).IsAssignableFrom(getter.Type))*/.ToList());
+                    type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                                   BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+                        .Where(field => !isObsolete(field) && !isMemberInBlackList(field))
+                        .Select(field => new
+                        {
+                            field.Name, field.IsStatic, ReadOnly = field.IsInitOnly || field.IsLiteral,
+                            Type = field.FieldType
+                        })
+                ).Where(info =>
+                    !IsDoNotGen(type, info.Name)) /*.Where(getter => !typeof(Delegate).IsAssignableFrom(getter.Type))*/
+                .ToList());
 
-            parameters.Set("setters", type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                .Where(prop => prop.GetIndexParameters().Length == 0 && prop.CanWrite && (prop.GetSetMethod() != null) && prop.Name != "Item" && !isObsolete(prop) && !isObsolete(prop.GetSetMethod()) && !isMemberInBlackList(prop) && !isMemberInBlackList(prop.GetSetMethod())).Select(prop => new { prop.Name, IsStatic = prop.GetSetMethod().IsStatic, Type = prop.PropertyType, IsProperty = true })
+            parameters.Set("setters", type
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                               BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+                .Where(prop => prop.GetIndexParameters().Length == 0 && prop.CanWrite &&
+                               (prop.GetSetMethod() != null) && prop.Name != "Item" && !isObsolete(prop) &&
+                               !isObsolete(prop.GetSetMethod()) && !isMemberInBlackList(prop) &&
+                               !isMemberInBlackList(prop.GetSetMethod())).Select(prop => new
+                    {prop.Name, IsStatic = prop.GetSetMethod().IsStatic, Type = prop.PropertyType, IsProperty = true})
                 .Concat(
-                    type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                    .Where(field => !isObsolete(field) && !isMemberInBlackList(field) && !field.IsInitOnly && !field.IsLiteral)
-                    .Select(field => new { field.Name, field.IsStatic, Type = field.FieldType, IsProperty = false })
-                ).Where(info => !IsDoNotGen(type, info.Name))/*.Where(setter => !typeof(Delegate).IsAssignableFrom(setter.Type))*/.ToList());
+                    type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                                   BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+                        .Where(field =>
+                            !isObsolete(field) && !isMemberInBlackList(field) && !field.IsInitOnly && !field.IsLiteral)
+                        .Select(field => new {field.Name, field.IsStatic, Type = field.FieldType, IsProperty = false})
+                ).Where(info =>
+                    !IsDoNotGen(type, info.Name)) /*.Where(setter => !typeof(Delegate).IsAssignableFrom(setter.Type))*/
+                .ToList());
 
-            parameters.Set("operators", type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+            parameters.Set("operators", type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                            BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
                 .Where(method => OpMethodNames.Contains(method.Name))
-                .GroupBy(method => method.Name, (k, v) => new { Name = k, Overloads = v.Cast<MethodBase>().OrderBy(mb => mb.GetParameters().Length).ToList() }).ToList());
-
-            var indexers = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Where(prop => prop.GetIndexParameters().Length > 0);
-
-            parameters.Set("indexers", indexers.Where(prop => prop.CanRead && (prop.GetGetMethod() != null)).Select(prop => prop.GetGetMethod())
-                .Where(method => method.GetParameters().Length == 1 && !method.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(string)))
+                .GroupBy(method => method.Name,
+                    (k, v) => new
+                        {Name = k, Overloads = v.Cast<MethodBase>().OrderBy(mb => mb.GetParameters().Length).ToList()})
                 .ToList());
 
-            parameters.Set("newindexers", indexers.Where(prop => prop.CanWrite && (prop.GetSetMethod() != null)).Select(prop => prop.GetSetMethod())
-                .Where(method => method.GetParameters().Length == 2 && !method.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(string)))
+            var indexers = type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(prop => prop.GetIndexParameters().Length > 0);
+
+            parameters.Set("indexers", indexers.Where(prop => prop.CanRead && (prop.GetGetMethod() != null))
+                .Select(prop => prop.GetGetMethod())
+                .Where(method =>
+                    method.GetParameters().Length == 1 &&
+                    !method.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(string)))
                 .ToList());
 
-            parameters.Set("events", type.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly).Where(e => !isObsolete(e) && !isMemberInBlackList(e))
-                .Where(ev=> ev.GetAddMethod() != null || ev.GetRemoveMethod() != null)
-                .Where(ev => !IsDoNotGen(type, ev.Name))
-                .Select(ev => new { IsStatic = ev.GetAddMethod() != null? ev.GetAddMethod().IsStatic: ev.GetRemoveMethod().IsStatic, ev.Name,
-                    CanSet = false, CanAdd = ev.GetRemoveMethod() != null, CanRemove = ev.GetRemoveMethod() != null, Type = ev.EventHandlerType})
+            parameters.Set("newindexers", indexers.Where(prop => prop.CanWrite && (prop.GetSetMethod() != null))
+                .Select(prop => prop.GetSetMethod())
+                .Where(method =>
+                    method.GetParameters().Length == 2 &&
+                    !method.GetParameters()[0].ParameterType.IsAssignableFrom(typeof(string)))
                 .ToList());
-            
+
+            parameters.Set("events",
+                type.GetEvents(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                               BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+                    .Where(e => !isObsolete(e) && !isMemberInBlackList(e))
+                    .Where(ev => ev.GetAddMethod() != null || ev.GetRemoveMethod() != null)
+                    .Where(ev => !IsDoNotGen(type, ev.Name))
+                    .Select(ev => new
+                    {
+                        IsStatic = ev.GetAddMethod() != null
+                            ? ev.GetAddMethod().IsStatic
+                            : ev.GetRemoveMethod().IsStatic,
+                        ev.Name,
+                        CanSet = false, CanAdd = ev.GetRemoveMethod() != null, CanRemove = ev.GetRemoveMethod() != null,
+                        Type = ev.EventHandlerType
+                    })
+                    .ToList());
+
             parameters.Set("lazymembers", lazyMemberInfos);
-            foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
+            foreach (var member in type.GetMembers(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                                                   BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
                 .Where(m => IsDoNotGen(type, m.Name))
-                .GroupBy(m=>m.Name).Select(g => g.First())
-                )
+                .GroupBy(m => m.Name).Select(g => g.First())
+            )
             {
-                switch(member.MemberType)
+                switch (member.MemberType)
                 {
                     case MemberTypes.Method:
                         MethodBase mb = member as MethodBase;
@@ -415,8 +499,11 @@ namespace CSObjectWrapEditor
                     case MemberTypes.Event:
                         EventInfo ev = member as EventInfo;
                         if (ev.GetAddMethod() == null && ev.GetRemoveMethod() == null) break;
-                        bool eventIsStatic = ev.GetAddMethod() != null ? ev.GetAddMethod().IsStatic : ev.GetRemoveMethod().IsStatic;
-                        lazyMemberInfos.Add(new LazyMemberInfo {
+                        bool eventIsStatic = ev.GetAddMethod() != null
+                            ? ev.GetAddMethod().IsStatic
+                            : ev.GetRemoveMethod().IsStatic;
+                        lazyMemberInfos.Add(new LazyMemberInfo
+                        {
                             Index = eventIsStatic ? "CLS_IDX" : "METHOD_IDX",
                             Name = member.Name,
                             MemberType = "LazyMemberTypes.Event",
@@ -455,6 +542,7 @@ namespace CSObjectWrapEditor
                                     IsStatic = isStatic ? "true" : "false"
                                 });
                             }
+
                             if (prop.CanWrite && prop.GetSetMethod() != null)
                             {
                                 var isStatic = prop.GetSetMethod().IsStatic;
@@ -467,6 +555,7 @@ namespace CSObjectWrapEditor
                                 });
                             }
                         }
+
                         break;
                 }
             }
@@ -484,20 +573,24 @@ namespace CSObjectWrapEditor
         {
             parameters.Set("type", type);
 
-            var itfs = new Type[] { type }.Concat(type.GetInterfaces());
+            var itfs = new Type[] {type}.Concat(type.GetInterfaces());
             parameters.Set("methods", itfs.SelectMany(i => i.GetMethods())
-                .Where(method => !method.IsSpecialName && !method.IsGenericMethod && !method.Name.StartsWith("op_") && !method.Name.StartsWith("add_") && !method.Name.StartsWith("remove_")) //GenericMethod can not be invoke becuase not static info available!
-                    .ToList());
+                .Where(method => !method.IsSpecialName && !method.IsGenericMethod && !method.Name.StartsWith("op_") &&
+                                 !method.Name.StartsWith("add_") &&
+                                 !method.Name
+                                     .StartsWith(
+                                         "remove_")) //GenericMethod can not be invoke becuase not static info available!
+                .ToList());
 
             parameters.Set("propertys", itfs.SelectMany(i => i.GetProperties())
                 .Where(prop => (prop.CanRead || prop.CanWrite) && prop.Name != "Item")
-                    .ToList());
+                .ToList());
 
             parameters.Set("events", itfs.SelectMany(i => i.GetEvents()).ToList());
 
             parameters.Set("indexers", itfs.SelectMany(i => i.GetProperties())
                 .Where(prop => (prop.CanRead || prop.CanWrite) && prop.Name == "Item")
-                    .ToList());
+                .ToList());
         }
 
         static bool isObsolete(MemberInfo mb)
@@ -518,6 +611,7 @@ namespace CSObjectWrapEditor
             {
                 return true;
             }
+
             return (type.DeclaringType != null) ? isObsolete(type.DeclaringType) : false;
         }
 
@@ -527,7 +621,7 @@ namespace CSObjectWrapEditor
             if (mb is FieldInfo && (mb as FieldInfo).FieldType.IsPointer) return true;
             if (mb is PropertyInfo && (mb as PropertyInfo).PropertyType.IsPointer) return true;
 
-            foreach(var filter in memberFilters)
+            foreach (var filter in memberFilters)
             {
                 if (filter(mb))
                 {
@@ -571,6 +665,7 @@ namespace CSObjectWrapEditor
                     {
                         continue;
                     }
+
                     bool paramsMatch = true;
 
                     for (int i = 0; i < parameters.Length; i++)
@@ -581,14 +676,18 @@ namespace CSObjectWrapEditor
                             break;
                         }
                     }
+
                     if (paramsMatch) return true;
                 }
             }
+
             return false;
         }
 
         static Dictionary<string, LuaFunction> templateCache = new Dictionary<string, LuaFunction>();
-        static void GenOne(Type type, Action<Type, LuaTable> type_info_getter, XLuaTemplate templateAsset, StreamWriter textWriter)
+
+        static void GenOne(Type type, Action<Type, LuaTable> type_info_getter, XLuaTemplate templateAsset,
+            StreamWriter textWriter)
         {
             if (isObsolete(type)) return;
             LuaFunction template;
@@ -631,12 +730,14 @@ namespace CSObjectWrapEditor
         {
             string filePath = save_path + "EnumWrap.cs";
             StreamWriter textWriter = new StreamWriter(filePath, false, Encoding.UTF8);
-            
+
             GenOne(null, (type, type_info) =>
             {
                 var type2fields = luaenv.NewTable();
-                foreach(var _type in types)
-                    type2fields.Set(_type, _type.GetFields(BindingFlags.Public | BindingFlags.Static).Where(x => !isMemberInBlackList(x)).ToArray());
+                foreach (var _type in types)
+                    type2fields.Set(_type,
+                        _type.GetFields(BindingFlags.Public | BindingFlags.Static).Where(x => !isMemberInBlackList(x))
+                            .ToArray());
                 type_info.Set("type2fields", type2fields);
                 type_info.Set("types", types.ToList());
             }, templateRef.LuaEnumWrap, textWriter);
@@ -646,7 +747,8 @@ namespace CSObjectWrapEditor
 
         static string NonmalizeName(string name)
         {
-            return name.Replace("+", "_").Replace(".", "_").Replace("`", "_").Replace("&", "_").Replace("[", "_").Replace("]", "_").Replace(",", "_");
+            return name.Replace("+", "_").Replace(".", "_").Replace("`", "_").Replace("&", "_").Replace("[", "_")
+                .Replace("]", "_").Replace(",", "_");
         }
 
         static void GenInterfaceBridge(IEnumerable<Type> types, string save_path)
@@ -657,10 +759,8 @@ namespace CSObjectWrapEditor
 
                 string filePath = save_path + NonmalizeName(wrap_type.ToString()) + "Bridge.cs";
                 StreamWriter textWriter = new StreamWriter(filePath, false, Encoding.UTF8);
-                GenOne(wrap_type, (type, type_info) =>
-                {
-                    getInterfaceInfo(type, type_info);
-                }, templateRef.LuaInterfaceBridge, textWriter);
+                GenOne(wrap_type, (type, type_info) => { getInterfaceInfo(type, type_info); },
+                    templateRef.LuaInterfaceBridge, textWriter);
                 textWriter.Close();
             }
         }
@@ -681,7 +781,7 @@ namespace CSObjectWrapEditor
 
             public int HashCode;
 
-            public ParameterInfoSimulation[]  GetParameters()
+            public ParameterInfoSimulation[] GetParameters()
             {
                 return ParameterInfos;
             }
@@ -702,6 +802,7 @@ namespace CSObjectWrapEditor
                 {
                     hashCode++;
                 }
+
                 hashCode += param.ParameterType.GetHashCode();
                 paramsExpect.Add(new ParameterInfoSimulation()
                 {
@@ -734,6 +835,7 @@ namespace CSObjectWrapEditor
                 {
                     return true;
                 }
+
                 if (type.IsGenericType)
                 {
                     foreach (var ga in type.GetGenericArguments())
@@ -744,6 +846,7 @@ namespace CSObjectWrapEditor
                         }
                     }
                 }
+
                 if (type.IsNested)
                 {
                     var parent = type.DeclaringType;
@@ -753,6 +856,7 @@ namespace CSObjectWrapEditor
                         {
                             return true;
                         }
+
                         if (parent.IsNested)
                         {
                             parent = parent.DeclaringType;
@@ -763,6 +867,7 @@ namespace CSObjectWrapEditor
                         }
                     }
                 }
+
                 return false;
             }
         }
@@ -773,6 +878,7 @@ namespace CSObjectWrapEditor
             {
                 return hasGenericParameter(type.GetElementType());
             }
+
             if (type.IsGenericType)
             {
                 foreach (var typeArg in type.GetGenericArguments())
@@ -782,8 +888,10 @@ namespace CSObjectWrapEditor
                         return true;
                     }
                 }
+
                 return false;
             }
+
             return type.IsGenericParameter;
         }
 
@@ -802,7 +910,9 @@ namespace CSObjectWrapEditor
                     Name = "self",
                     IsOut = false,
                     IsIn = true,
-                    ParameterType = (hotfixMethod.DeclaringType.IsValueType && !ignoreValueType) ? hotfixMethod.DeclaringType : typeof(object),
+                    ParameterType = (hotfixMethod.DeclaringType.IsValueType && !ignoreValueType)
+                        ? hotfixMethod.DeclaringType
+                        : typeof(object),
                     IsParamArray = false
                 });
                 hashCode += paramsExpect[0].ParameterType.GetHashCode();
@@ -815,14 +925,18 @@ namespace CSObjectWrapEditor
                     Name = param.Name,
                     IsOut = param.IsOut,
                     IsIn = param.IsIn,
-                    ParameterType = (param.ParameterType.IsByRef || (param.ParameterType.IsValueType && !ignoreValueType)
-                      || param.IsDefined(typeof(System.ParamArrayAttribute), false)) ? param.ParameterType : typeof(object),
+                    ParameterType =
+                        (param.ParameterType.IsByRef || (param.ParameterType.IsValueType && !ignoreValueType)
+                                                     || param.IsDefined(typeof(System.ParamArrayAttribute), false))
+                            ? param.ParameterType
+                            : typeof(object),
                     IsParamArray = param.IsDefined(typeof(System.ParamArrayAttribute), false)
                 };
                 if (param.IsOut)
                 {
                     hashCode++;
                 }
+
                 hashCode += paramExpect.ParameterType.GetHashCode();
                 paramsExpect.Add(paramExpect);
             }
@@ -844,10 +958,12 @@ namespace CSObjectWrapEditor
                 {
                     return false;
                 }
+
                 if (x.ReturnType != y.ReturnType)
                 {
                     return false;
                 }
+
                 var xParams = x.GetParameters();
                 var yParams = y.GetParameters();
                 if (xParams.Length != yParams.Length)
@@ -866,6 +982,7 @@ namespace CSObjectWrapEditor
                 var lastPos = xParams.Length - 1;
                 return lastPos < 0 || xParams[lastPos].IsParamArray == yParams[lastPos].IsParamArray;
             }
+
             public int GetHashCode(MethodInfoSimulation obj)
             {
                 return obj.HashCode;
@@ -877,21 +994,25 @@ namespace CSObjectWrapEditor
             bool ignoreValueType = hotfixType.HasFlag(HotfixFlag.ValueTypeBoxing);
             //ignoreValueType = true;
 
-            if (!method.IsConstructor && (isNotPublic((method as MethodInfo).ReturnType) || hasGenericParameter((method as MethodInfo).ReturnType))) return true;
+            if (!method.IsConstructor && (isNotPublic((method as MethodInfo).ReturnType) ||
+                                          hasGenericParameter((method as MethodInfo).ReturnType))) return true;
 
-            if (!method.IsStatic 
-                &&(((method.DeclaringType.IsValueType && !ignoreValueType) && isNotPublic(method.DeclaringType)) || hasGenericParameter(method.DeclaringType)))
+            if (!method.IsStatic
+                && (((method.DeclaringType.IsValueType && !ignoreValueType) && isNotPublic(method.DeclaringType)) ||
+                    hasGenericParameter(method.DeclaringType)))
             {
                 return true;
             }
 
             foreach (var param in method.GetParameters())
             {
-                if ((((param.ParameterType.IsValueType && !ignoreValueType) 
-                    || param.ParameterType.IsByRef || param.IsDefined(typeof(System.ParamArrayAttribute), false)) && isNotPublic(param.ParameterType)) 
+                if ((((param.ParameterType.IsValueType && !ignoreValueType)
+                      || param.ParameterType.IsByRef || param.IsDefined(typeof(System.ParamArrayAttribute), false)) &&
+                     isNotPublic(param.ParameterType))
                     || hasGenericParameter(param.ParameterType))
                     return true;
             }
+
             return false;
         }
 
@@ -904,13 +1025,18 @@ namespace CSObjectWrapEditor
         {
             string filePath = save_path + "DelegatesGensBridge.cs";
             StreamWriter textWriter = new StreamWriter(filePath, false, Encoding.UTF8);
-            types = types.Where(type => !type.GetMethod("Invoke").GetParameters().Any(paramInfo => paramInfo.ParameterType.IsGenericParameter));
+            types = types.Where(type =>
+                !type.GetMethod("Invoke").GetParameters().Any(paramInfo => paramInfo.ParameterType.IsGenericParameter));
             var hotfxDelegates = new List<MethodInfoSimulation>();
             var comparer = new MethodInfoSimulationComparer();
 
-            var bindingAttrOfMethod = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.NonPublic;
-            var bindingAttrOfConstructor = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.NonPublic;
-            foreach (var type in (from type in hotfix_check_types where isDefined(type, typeof(HotfixAttribute)) select type))
+            var bindingAttrOfMethod = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static |
+                                      BindingFlags.DeclaredOnly | BindingFlags.NonPublic;
+            var bindingAttrOfConstructor = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly |
+                                           BindingFlags.NonPublic;
+            foreach (var type in (from type in hotfix_check_types
+                where isDefined(type, typeof(HotfixAttribute))
+                select type))
             {
                 var ca = GetCustomAttribute(type, typeof(HotfixAttribute));
 #if XLUA_GENERAL
@@ -920,12 +1046,14 @@ namespace CSObjectWrapEditor
 #endif
                 HotfixCfg[type] = hotfixType;
             }
+
             foreach (var kv in HotfixCfg)
             {
                 if (kv.Key.Name.Contains("<") || kv.Value.HasFlag(HotfixFlag.Inline))
                 {
                     continue;
                 }
+
                 bool ignoreProperty = kv.Value.HasFlag(HotfixFlag.IgnoreProperty);
                 bool ignoreNotPublic = kv.Value.HasFlag(HotfixFlag.IgnoreNotPublic);
                 bool ignoreCompilerGenerated = kv.Value.HasFlag(HotfixFlag.IgnoreCompilerGenerated);
@@ -933,32 +1061,36 @@ namespace CSObjectWrapEditor
                 {
                     continue;
                 }
+
                 //ignoreProperty = true;
                 hotfxDelegates.AddRange(kv.Key.GetMethods(bindingAttrOfMethod)
                     .Where(method => method.GetMethodBody() != null)
                     .Where(method => !method.Name.Contains("<"))
                     .Where(method => !ignoreCompilerGenerated || !isDefined(method, typeof(CompilerGeneratedAttribute)))
                     .Where(method => !ignoreNotPublic || method.IsPublic)
-                    .Where(method => !ignoreProperty || !method.IsSpecialName || (!method.Name.StartsWith("get_") && !method.Name.StartsWith("set_")))
+                    .Where(method =>
+                        !ignoreProperty || !method.IsSpecialName ||
+                        (!method.Name.StartsWith("get_") && !method.Name.StartsWith("set_")))
                     .Cast<MethodBase>()
                     .Concat(kv.Key.GetConstructors(bindingAttrOfConstructor).Cast<MethodBase>())
                     .Where(method => !injectByGeneric(method, kv.Value))
                     .Select(method => makeHotfixMethodInfoSimulation(method, kv.Value)));
             }
+
             hotfxDelegates = hotfxDelegates.Distinct(comparer).ToList();
-            for(int i = 0; i < hotfxDelegates.Count; i++)
+            for (int i = 0; i < hotfxDelegates.Count; i++)
             {
                 hotfxDelegates[i].DeclaringTypeName = "__Gen_Hotfix_Delegate" + i;
             }
 
-            var delegates_groups = types.Select(delegate_type => makeMethodInfoSimulation(delegate_type.GetMethod("Invoke")))
+            var delegates_groups = types
+                .Select(delegate_type => makeMethodInfoSimulation(delegate_type.GetMethod("Invoke")))
                 .Where(d => d.DeclaringType.FullName != null)
                 .Concat(hotfxDelegates)
-                .GroupBy(d => d, comparer).Select((group) => new { Key = group.Key, Value = group.ToList()});
-            GenOne(typeof(DelegateBridge), (type, type_info) =>
-            {
-                type_info.Set("delegates_groups", delegates_groups.ToList());
-            }, templateRef.LuaDelegateBridge, textWriter);
+                .GroupBy(d => d, comparer).Select((group) => new {Key = group.Key, Value = group.ToList()});
+            GenOne(typeof(DelegateBridge),
+                (type, type_info) => { type_info.Set("delegates_groups", delegates_groups.ToList()); },
+                templateRef.LuaDelegateBridge, textWriter);
             textWriter.Close();
         }
 
@@ -970,29 +1102,37 @@ namespace CSObjectWrapEditor
             GenOne(typeof(ObjectTranslator), (type, type_info) =>
             {
                 type_info.Set("purevaluetypes", types
-                     .Where(t => t.IsEnum || (!t.IsPrimitive && SizeOf(t) != -1))
-                     .Select(t => new {
-                         Type = t,
-                         Size = SizeOf(t),
-                         Flag = t.IsEnum ? OptimizeFlag.Default : OptimizeCfg[t],
-                         FieldInfos = (t.IsEnum || OptimizeCfg[t] == OptimizeFlag.Default) ? null : getXluaTypeInfo(t, emptyMap).FieldInfos
-                     }).ToList());
+                    .Where(t => t.IsEnum || (!t.IsPrimitive && SizeOf(t) != -1))
+                    .Select(t => new
+                    {
+                        Type = t,
+                        Size = SizeOf(t),
+                        Flag = t.IsEnum ? OptimizeFlag.Default : OptimizeCfg[t],
+                        FieldInfos = (t.IsEnum || OptimizeCfg[t] == OptimizeFlag.Default)
+                            ? null
+                            : getXluaTypeInfo(t, emptyMap).FieldInfos
+                    }).ToList());
                 type_info.Set("tableoptimzetypes", types.Where(t => !t.IsEnum && SizeOf(t) == -1)
-                     .Select(t => new { Type = t, Fields = t.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly) })
-                     .ToList());
+                    .Select(t => new
+                    {
+                        Type = t,
+                        Fields = t.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    })
+                    .ToList());
             }, templateRef.LuaWrapPusher, textWriter);
             textWriter.Close();
         }
 
         static void GenWrap(IEnumerable<Type> types, string save_path)
         {
-            types = types.Where(type=>!type.IsEnum);
+            types = types.Where(type => !type.IsEnum);
 
 #if GENERIC_SHARING
             types = types.GroupBy(t => t.IsGenericType ? t.GetGenericTypeDefinition() : t).Select(g => g.Key);
 #endif
 
-            var typeMap = types.ToDictionary(type => {
+            var typeMap = types.ToDictionary(type =>
+            {
                 //Debug.Log("type:" + type);
                 return type.ToString();
             });
@@ -1006,21 +1146,19 @@ namespace CSObjectWrapEditor
                     GenOne(wrap_type, (type, type_info) =>
                     {
                         type_info.Set("type", type);
-                        type_info.Set("fields", type.GetFields(BindingFlags.GetField | BindingFlags.Public | BindingFlags.Static)
-                            .Where(field => !isObsolete(field))
-                            .ToList());
+                        type_info.Set("fields",
+                            type.GetFields(BindingFlags.GetField | BindingFlags.Public | BindingFlags.Static)
+                                .Where(field => !isObsolete(field))
+                                .ToList());
                     }, templateRef.LuaEnumWrap, textWriter);
                 }
                 else if (typeof(Delegate).IsAssignableFrom(wrap_type))
                 {
-
-
                     GenOne(wrap_type, (type, type_info) =>
                     {
                         type_info.Set("type", type);
                         type_info.Set("delegate", type.GetMethod("Invoke"));
                     }, templateRef.LuaDelegateWrap, textWriter);
-
                 }
                 else
                 {
@@ -1030,9 +1168,11 @@ namespace CSObjectWrapEditor
                         {
                             type_info.Set("base", type.BaseType);
                         }
+
                         getClassInfo(type, type_info);
                     }, templateRef.LuaClassWrap, textWriter);
                 }
+
                 textWriter.Close();
             }
         }
@@ -1056,6 +1196,7 @@ namespace CSObjectWrapEditor
             {
                 return XLua.Utils.IsParamsMatch(x.GetMethod("Invoke"), y.GetMethod("Invoke"));
             }
+
             public int GetHashCode(Type obj)
             {
                 int hc = 0;
@@ -1065,6 +1206,7 @@ namespace CSObjectWrapEditor
                 {
                     hc += pi.ParameterType.GetHashCode();
                 }
+
                 return hc;
             }
         }
@@ -1094,16 +1236,17 @@ namespace CSObjectWrapEditor
                 var argumentType = genericArguments[i];
                 var parameterConstraints = argumentType.GetGenericParameterConstraints();
                 Type parameterConstraint = parameterConstraints[0];
-                foreach(var type in argumentType.GetGenericParameterConstraints())
+                foreach (var type in argumentType.GetGenericParameterConstraints())
                 {
                     if (parameterConstraint.IsAssignableFrom(type))
                     {
                         parameterConstraint = type;
                     }
                 }
-                
+
                 constraintedArgumentTypes[i] = parameterConstraint;
             }
+
             return method.MakeGenericMethod(constraintedArgumentTypes);
         }
 
@@ -1119,19 +1262,19 @@ namespace CSObjectWrapEditor
             var lookup = LuaCallCSharp.Distinct().ToDictionary(t => t);
 
             var extension_methods_from_lcs = (from t in LuaCallCSharp
-                                    where isDefined(t, typeof(ExtensionAttribute))
-                                    from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                                    where isDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
-                                    where !method.ContainsGenericParameters || isSupportedGenericMethod(method)
-                                    select makeGenericMethodIfNeeded(method))
-                                    .Where(method => !lookup.ContainsKey(method.GetParameters()[0].ParameterType));
+                    where isDefined(t, typeof(ExtensionAttribute))
+                    from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                    where isDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
+                    where !method.ContainsGenericParameters || isSupportedGenericMethod(method)
+                    select makeGenericMethodIfNeeded(method))
+                .Where(method => !lookup.ContainsKey(method.GetParameters()[0].ParameterType));
 
             var extension_methods = (from t in ReflectionUse
-                                     where isDefined(t, typeof(ExtensionAttribute))
-                                     from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                                     where isDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
-                                     where !method.ContainsGenericParameters || isSupportedGenericMethod(method)
-                                     select makeGenericMethodIfNeeded(method)).Concat(extension_methods_from_lcs);
+                where isDefined(t, typeof(ExtensionAttribute))
+                from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                where isDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
+                where !method.ContainsGenericParameters || isSupportedGenericMethod(method)
+                select makeGenericMethodIfNeeded(method)).Concat(extension_methods_from_lcs);
             GenOne(typeof(DelegateBridgeBase), (type, type_info) =>
             {
 #if GENERIC_SHARING
@@ -1168,12 +1311,14 @@ namespace CSObjectWrapEditor
             if (!type.IsPrimitive && type != typeof(decimal))
             {
                 cb(type);
-                foreach(var fieldInfo in type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                foreach (var fieldInfo in type.GetFields(BindingFlags.Public | BindingFlags.Instance |
+                                                         BindingFlags.DeclaredOnly))
                 {
                     AllSubStruct(fieldInfo.FieldType, cb);
                 }
 
-                foreach(var propInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                foreach (var propInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance |
+                                                            BindingFlags.DeclaredOnly))
                 {
                     if ((AdditionalProperties.ContainsKey(type) && AdditionalProperties[type].Contains(propInfo.Name))
                         || isDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
@@ -1203,13 +1348,18 @@ namespace CSObjectWrapEditor
         static XluaTypeInfo getXluaTypeInfo(Type t, Dictionary<Type, Type> set)
         {
             var fs = t.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                        .Select(fi => new XluaFieldInfo { Name = fi.Name, Type = fi.FieldType, IsField = true, Size = SizeOf(fi.FieldType) })
-                        .Concat(t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                        .Where(prop => {
-                            return (AdditionalProperties.ContainsKey(t) && AdditionalProperties[t].Contains(prop.Name))
-                                || isDefined(prop, typeof(AdditionalPropertiesAttribute));
-                        })
-                        .Select(prop => new XluaFieldInfo { Name = prop.Name, Type = prop.PropertyType, IsField = false, Size = SizeOf(prop.PropertyType) }));
+                .Select(fi => new XluaFieldInfo
+                    {Name = fi.Name, Type = fi.FieldType, IsField = true, Size = SizeOf(fi.FieldType)})
+                .Concat(t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                    .Where(prop =>
+                    {
+                        return (AdditionalProperties.ContainsKey(t) && AdditionalProperties[t].Contains(prop.Name))
+                               || isDefined(prop, typeof(AdditionalPropertiesAttribute));
+                    })
+                    .Select(prop => new XluaFieldInfo
+                    {
+                        Name = prop.Name, Type = prop.PropertyType, IsField = false, Size = SizeOf(prop.PropertyType)
+                    }));
             int float_field_count = 0;
             bool only_float = true;
             foreach (var f in fs)
@@ -1224,6 +1374,7 @@ namespace CSObjectWrapEditor
                     break;
                 }
             }
+
             List<List<XluaFieldInfo>> grouped_field = null;
             if (only_float && float_field_count > 1)
             {
@@ -1239,9 +1390,12 @@ namespace CSObjectWrapEditor
                         group = null;
                     }
                 }
+
                 if (group != null) grouped_field.Add(group);
             }
-            return new XluaTypeInfo { Type = t, FieldInfos = fs.ToList(), FieldGroup = grouped_field, IsRoot = set.ContainsKey(t) };
+
+            return new XluaTypeInfo
+                {Type = t, FieldInfos = fs.ToList(), FieldGroup = grouped_field, IsRoot = set.ContainsKey(t)};
         }
 
         public static void GenPackUnpack(IEnumerable<Type> types, string save_path)
@@ -1249,20 +1403,18 @@ namespace CSObjectWrapEditor
             var set = types.ToDictionary(type => type);
             List<Type> all_types = new List<Type>();
 
-            foreach(var type in types)
+            foreach (var type in types)
             {
-                AllSubStruct(type, (t) =>
-                {
-                    all_types.Add(t);
-                });
+                AllSubStruct(type, (t) => { all_types.Add(t); });
             }
 
             string filePath = save_path + "PackUnpack.cs";
             StreamWriter textWriter = new StreamWriter(filePath, false, Encoding.UTF8);
-            GenOne(typeof(CopyByValue), (type, type_info) =>
-            {
-                type_info.Set("type_infos", all_types.Distinct().Select(t => getXluaTypeInfo(t, set)).ToList());
-            }, templateRef.PackUnpack, textWriter);
+            GenOne(typeof(CopyByValue),
+                (type, type_info) =>
+                {
+                    type_info.Set("type_infos", all_types.Distinct().Select(t => getXluaTypeInfo(t, set)).ToList());
+                }, templateRef.PackUnpack, textWriter);
             textWriter.Close();
         }
 
@@ -1304,7 +1456,8 @@ namespace CSObjectWrapEditor
             }
             else
             {
-                throw new InvalidOperationException("Only field/property with the type IEnumerable<Type> can be marked " + attr.GetType().Name);
+                throw new InvalidOperationException(
+                    "Only field/property with the type IEnumerable<Type> can be marked " + attr.GetType().Name);
             }
 #if XLUA_GENERAL
             if (attr != null && attr.GetType().ToString() == typeof(GCOptimizeAttribute).ToString())
@@ -1321,7 +1474,7 @@ namespace CSObjectWrapEditor
                 }
                 else if (obj is IEnumerable<Type>)
                 {
-                    foreach(var type in (obj as IEnumerable<Type>))
+                    foreach (var type in (obj as IEnumerable<Type>))
                     {
                         OptimizeCfg.Add(type, flag);
                     }
@@ -1362,18 +1515,22 @@ namespace CSObjectWrapEditor
                 }
 #endif
             }
+
             if (isDefined(test, typeof(CSharpCallLuaAttribute)))
             {
                 AddToList(CSharpCallLua, get_cfg, GetCustomAttribute(test, typeof(CSharpCallLuaAttribute)));
             }
+
             if (isDefined(test, typeof(GCOptimizeAttribute)))
             {
                 AddToList(GCOptimizeList, get_cfg, GetCustomAttribute(test, typeof(GCOptimizeAttribute)));
             }
+
             if (isDefined(test, typeof(ReflectionUseAttribute)))
             {
                 AddToList(ReflectionUse, get_cfg, GetCustomAttribute(test, typeof(ReflectionUseAttribute)));
             }
+
             if (isDefined(test, typeof(HotfixAttribute)))
             {
                 object cfg = get_cfg();
@@ -1387,29 +1544,35 @@ namespace CSObjectWrapEditor
 #endif
                     foreach (var type in cfg as IEnumerable<Type>)
                     {
-                        if (!HotfixCfg.ContainsKey(type) && !isObsolete(type) 
-                            && !type.IsEnum && !typeof(Delegate).IsAssignableFrom(type)
-                            && (!type.IsGenericType || type.IsGenericTypeDefinition) 
-                            && (type.Namespace == null || (type.Namespace != "XLua" && !type.Namespace.StartsWith("XLua.")))
-                            && (assemblyList.Contains(type.Module.Assembly.GetName().Name)))
+                        if (!HotfixCfg.ContainsKey(type) && !isObsolete(type)
+                                                         && !type.IsEnum && !typeof(Delegate).IsAssignableFrom(type)
+                                                         && (!type.IsGenericType || type.IsGenericTypeDefinition)
+                                                         && (type.Namespace == null ||
+                                                             (type.Namespace != "XLua" &&
+                                                              !type.Namespace.StartsWith("XLua.")))
+                                                         && (assemblyList.Contains(type.Module.Assembly.GetName()
+                                                             .Name)))
                         {
                             HotfixCfg.Add(type, hotfixType);
                         }
                     }
                 }
             }
+
             if (isDefined(test, typeof(BlackListAttribute))
-                        && (typeof(List<List<string>>)).IsAssignableFrom(cfg_type))
+                && (typeof(List<List<string>>)).IsAssignableFrom(cfg_type))
             {
                 BlackList.AddRange(get_cfg() as List<List<string>>);
             }
-            if (isDefined(test, typeof(BlackListAttribute)) && typeof(Func<MemberInfo, bool>).IsAssignableFrom(cfg_type))
+
+            if (isDefined(test, typeof(BlackListAttribute)) &&
+                typeof(Func<MemberInfo, bool>).IsAssignableFrom(cfg_type))
             {
                 memberFilters.Add(get_cfg() as Func<MemberInfo, bool>);
             }
 
             if (isDefined(test, typeof(AdditionalPropertiesAttribute))
-                        && (typeof(Dictionary<Type, List<string>>)).IsAssignableFrom(cfg_type))
+                && (typeof(Dictionary<Type, List<string>>)).IsAssignableFrom(cfg_type))
             {
                 var cfg = get_cfg() as Dictionary<Type, List<string>>;
                 foreach (var kv in cfg)
@@ -1422,7 +1585,7 @@ namespace CSObjectWrapEditor
             }
 
             if (isDefined(test, typeof(DoNotGenAttribute))
-                        && (typeof(Dictionary<Type, List<string>>)).IsAssignableFrom(cfg_type))
+                && (typeof(Dictionary<Type, List<string>>)).IsAssignableFrom(cfg_type))
             {
                 var cfg = get_cfg() as Dictionary<Type, List<string>>;
                 foreach (var kv in cfg)
@@ -1433,6 +1596,7 @@ namespace CSObjectWrapEditor
                         set = new HashSet<string>();
                         DoNotGen.Add(kv.Key, set);
                     }
+
                     set.UnionWith(kv.Value);
                 }
             }
@@ -1451,6 +1615,7 @@ namespace CSObjectWrapEditor
                     return true;
                 }
             }
+
             return false;
         }
 
@@ -1489,22 +1654,25 @@ namespace CSObjectWrapEditor
 
                 if (!t.IsAbstract || !t.IsSealed) continue;
 
-                var fields = t.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                var fields = t.GetFields(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic |
+                                         BindingFlags.DeclaredOnly);
                 for (int i = 0; i < fields.Length; i++)
                 {
                     var field = fields[i];
                     MergeCfg(field, field.FieldType, () => field.GetValue(null));
                 }
 
-                var props = t.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+                var props = t.GetProperties(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic |
+                                            BindingFlags.DeclaredOnly);
                 for (int i = 0; i < props.Length; i++)
                 {
                     var prop = props[i];
                     MergeCfg(prop, prop.PropertyType, () => prop.GetValue(null, null));
                 }
             }
+
             LuaCallCSharp = LuaCallCSharp.Distinct()
-                .Where(type=> IsPublic(type) && !isObsolete(type) && !type.IsGenericTypeDefinition)
+                .Where(type => IsPublic(type) && !isObsolete(type) && !type.IsGenericTypeDefinition)
                 .Where(type => !typeof(Delegate).IsAssignableFrom(type))
                 .Where(type => !type.Name.Contains("<"))
                 .ToList();
@@ -1522,17 +1690,17 @@ namespace CSObjectWrapEditor
 
         static Dictionary<Type, int> type_size = new Dictionary<Type, int>()
         {
-            { typeof(byte), 1 },
-            { typeof(sbyte), 1 },
-            { typeof(short), 2 },
-            { typeof(ushort), 2 },
-            { typeof(int), 4 },
-            { typeof(uint), 4 },
-            { typeof(long), 8 },
-            { typeof(ulong), 8 },
-            { typeof(float), 4 },
-            { typeof(double), 8 },
-            { typeof(decimal), 16 }
+            {typeof(byte), 1},
+            {typeof(sbyte), 1},
+            {typeof(short), 2},
+            {typeof(ushort), 2},
+            {typeof(int), 4},
+            {typeof(uint), 4},
+            {typeof(long), 8},
+            {typeof(ulong), 8},
+            {typeof(float), 4},
+            {typeof(double), 8},
+            {typeof(decimal), 16}
         };
 
         static int SizeOf(Type type)
@@ -1548,7 +1716,8 @@ namespace CSObjectWrapEditor
             }
 
             int size = 0;
-            foreach(var fieldInfo in type.GetFields(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+            foreach (var fieldInfo in type.GetFields(BindingFlags.Public | BindingFlags.Instance |
+                                                     BindingFlags.DeclaredOnly))
             {
                 int t_size = SizeOf(fieldInfo.FieldType);
                 if (t_size == -1)
@@ -1556,13 +1725,18 @@ namespace CSObjectWrapEditor
                     size = -1;
                     break;
                 }
+
                 size += t_size;
             }
+
             if (size != -1)
             {
-                foreach (var propInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                foreach (var propInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance |
+                                                            BindingFlags.DeclaredOnly))
                 {
-                    if ((AdditionalProperties.ContainsKey(type) && AdditionalProperties[type].Contains(propInfo.Name)) || isDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
+                    if ((AdditionalProperties.ContainsKey(type) &&
+                         AdditionalProperties[type].Contains(propInfo.Name)) ||
+                        isDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
                     {
                         int t_size = SizeOf(propInfo.PropertyType);
                         if (t_size == -1)
@@ -1570,6 +1744,7 @@ namespace CSObjectWrapEditor
                             size = -1;
                             break;
                         }
+
                         size += t_size;
                     }
                 }
@@ -1583,12 +1758,13 @@ namespace CSObjectWrapEditor
             return size;
         }
 
-        public static void Gen(IEnumerable<Type> wraps, IEnumerable<Type> gc_optimze_list, IEnumerable<Type> itf_bridges, string save_path)
+        public static void Gen(IEnumerable<Type> wraps, IEnumerable<Type> gc_optimze_list,
+            IEnumerable<Type> itf_bridges, string save_path)
         {
             templateCache.Clear();
             Directory.CreateDirectory(save_path);
             GenWrap(wraps, save_path);
-            GenWrapPusher(gc_optimze_list.Concat(wraps.Where(type=>type.IsEnum)).Distinct(), save_path);
+            GenWrapPusher(gc_optimze_list.Concat(wraps.Where(type => type.IsEnum)).Distinct(), save_path);
             GenPackUnpack(gc_optimze_list.Where(type => !type.IsPrimitive && SizeOf(type) != -1), save_path);
             GenInterfaceBridge(itf_bridges, save_path);
         }
@@ -1638,12 +1814,20 @@ namespace CSObjectWrapEditor
         static void callCustomGen()
         {
             foreach (var method in (from type in XLua.Utils.GetAllTypes()
-                               from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                               where method.IsDefined(typeof(GenCodeMenuAttribute), false) select method))
+                from method in type.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                where method.IsDefined(typeof(GenCodeMenuAttribute), false)
+                select method))
             {
                 method.Invoke(null, new object[] { });
             }
         }
+
+        [MenuItem("XLua/Generate Code", true, 1)]
+        public static bool CheckGenAll()
+        {
+            return !EditorApplication.isCompiling;
+        }
+
 
         [MenuItem("XLua/Generate Code", false, 1)]
         public static void GenAll()
@@ -1660,7 +1844,8 @@ namespace CSObjectWrapEditor
             GetGenConfig(XLua.Utils.GetAllTypes());
             luaenv.DoString("require 'TemplateCommon'");
             var gen_push_types_setter = luaenv.Global.Get<LuaFunction>("SetGenPushAndUpdateTypes");
-            gen_push_types_setter.Call(GCOptimizeList.Where(t => !t.IsPrimitive && SizeOf(t) != -1).Concat(LuaCallCSharp.Where(t => t.IsEnum)).Distinct().ToList());
+            gen_push_types_setter.Call(GCOptimizeList.Where(t => !t.IsPrimitive && SizeOf(t) != -1)
+                .Concat(LuaCallCSharp.Where(t => t.IsEnum)).Distinct().ToList());
             var xlua_classes_setter = luaenv.Global.Get<LuaFunction>("SetXLuaClasses");
             xlua_classes_setter.Call(XLua.Utils.GetAllTypes().Where(t => t.Namespace == "XLua").ToList());
             GenDelegateBridges(XLua.Utils.GetAllTypes(false));
@@ -1668,9 +1853,119 @@ namespace CSObjectWrapEditor
             GenCodeForClass();
             GenLuaRegister();
             callCustomGen();
+            GenXLuaEnvStarterPrefab();
             Debug.Log("finished! use " + (DateTime.Now - start).TotalMilliseconds + " ms");
             AssetDatabase.Refresh();
         }
+        
+        static void GenXLuaEnvStarterPrefab()
+        {
+            string scriptContent = @"using UnityEngine;
+ using XLua;
+ 
+ public class XLuaEnvStarter : MonoBehaviour
+ {
+     void Awake()
+     {
+         LuaEnv.CreateObjectTranslatorDelegate = (env, ptr) => { return new ObjectTranslatorExtensions(env, ptr); };
+     }
+
+     void Start()
+    {
+        Destroy(this.gameObject);
+    }
+ }";
+            string scriptMetaContent = @"fileFormatVersion: 2
+guid: 86abd71936b9b084ab75a6b7e8b559dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+";
+            #region prefab content
+            string prefabContent = @"%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1728669989506548}
+  m_IsPrefabParent: 1
+--- !u!1 &1728669989506548
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4991214692489820}
+  - component: {fileID: 114636356176379218}
+  m_Layer: 0
+  m_Name: LuaEnvStarter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4991214692489820
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1728669989506548}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114636356176379218
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1728669989506548}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86abd71936b9b084ab75a6b7e8b559dd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+";
+            #endregion prefab content
+            
+            string prefabMetaContent = @"fileFormatVersion: 2
+guid: 2aa2124fc33d5a64fa19d71c85cacf7d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+";
+
+            var path = GeneratorConfig.common_path + "Resources/";
+            if (!Directory.Exists(path))
+            {
+                Directory.CreateDirectory(path);
+            }
+
+            File.WriteAllText(path + "LuaEnvStarter.prefab", prefabContent);
+            File.WriteAllText(path + "LuaEnvStarter.prefab.meta", prefabMetaContent);
+            File.WriteAllText(GeneratorConfig.common_path + "XLuaEnvStarter.cs", scriptContent);
+            File.WriteAllText(GeneratorConfig.common_path + "XLuaEnvStarter.cs.meta", scriptMetaContent);
+        }
+
 
 #if UNITY_EDITOR_OSX || UNITY_EDITOR_WIN
         public static void GenUsingCLI()
@@ -1692,14 +1987,17 @@ namespace CSObjectWrapEditor
             var searchPaths = new List<string>();
             foreach (var path in
                 (from asm in AppDomain.CurrentDomain.GetAssemblies() select asm.ManifestModule.FullyQualifiedName)
-                 .Distinct())
+                .Distinct())
             {
                 try
                 {
                     searchPaths.Add(Path.GetDirectoryName(path));
                 }
-                catch { }
+                catch
+                {
+                }
             }
+
             args.AddRange(searchPaths.Distinct());
 
             System.Diagnostics.Process process = new System.Diagnostics.Process();
@@ -1729,6 +2027,12 @@ namespace CSObjectWrapEditor
         }
 #endif
 
+        [MenuItem("XLua/Clear Generated Code", true, 1)]
+        public static bool CheckClearAll()
+        {
+            return !EditorApplication.isCompiling;
+        }
+
         [MenuItem("XLua/Clear Generated Code", false, 2)]
         public static void ClearAll()
         {
@@ -1743,7 +2047,8 @@ namespace CSObjectWrapEditor
 
             LuaFunction template = XLua.TemplateEngine.LuaTemplate.Compile(luaenv,
                 template_src);
-            foreach (var gen_task in get_tasks(luaenv, new UserConfig() {
+            foreach (var gen_task in get_tasks(luaenv, new UserConfig()
+            {
                 LuaCallCSharp = LuaCallCSharp,
                 CSharpCallLua = CSharpCallLua,
                 ReflectionUse = ReflectionUse
@@ -1762,7 +2067,8 @@ namespace CSObjectWrapEditor
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError("gen file fail! template=" + template_src + ", err=" + e.Message + ", stack=" + e.StackTrace);
+                    Debug.LogError("gen file fail! template=" + template_src + ", err=" + e.Message + ", stack=" +
+                                   e.StackTrace);
                 }
                 finally
                 {
@@ -1775,7 +2081,6 @@ namespace CSObjectWrapEditor
 
         private static bool isSupportedGenericMethod(MethodInfo method)
         {
-
             if (!method.ContainsGenericParameters)
                 return true;
             var methodParameters = method.GetParameters();
@@ -1786,11 +2091,13 @@ namespace CSObjectWrapEditor
                 if (!isSupportGenericParameter(parameterType, true, ref _hasGenericParameter))
                     return false;
             }
+
             return _hasGenericParameter;
         }
-        private static bool isSupportGenericParameter(Type parameterType,bool checkConstraint, ref bool _hasGenericParameter)
-        {
 
+        private static bool isSupportGenericParameter(Type parameterType, bool checkConstraint,
+            ref bool _hasGenericParameter)
+        {
             if (parameterType.IsGenericParameter)
             {
                 if (!checkConstraint)
@@ -1799,19 +2106,22 @@ namespace CSObjectWrapEditor
                 if (parameterConstraints.Length == 0) return false;
                 foreach (var parameterConstraint in parameterConstraints)
                 {
-                    if (!parameterConstraint.IsClass || (parameterConstraint == typeof(ValueType)) || Generator.hasGenericParameter(parameterConstraint))
+                    if (!parameterConstraint.IsClass || (parameterConstraint == typeof(ValueType)) ||
+                        Generator.hasGenericParameter(parameterConstraint))
                         return false;
                 }
+
                 _hasGenericParameter = true;
             }
-            else if(parameterType.IsGenericType)
+            else if (parameterType.IsGenericType)
             {
                 foreach (var argument in parameterType.GetGenericArguments())
                 {
-                    if (!isSupportGenericParameter(argument,false, ref _hasGenericParameter))
+                    if (!isSupportGenericParameter(argument, false, ref _hasGenericParameter))
                         return false;
                 }
             }
+
             return true;
         }
 #if !XLUA_GENERAL
@@ -1822,6 +2132,7 @@ namespace CSObjectWrapEditor
             {
                 return;
             }
+
             if (!DelegateBridge.Gen_Flag)
             {
                 throw new InvalidOperationException("Code has not been genrated, may be not work in phone!");

--- a/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
@@ -124,7 +124,7 @@ namespace XLua.CSObjectWrap
     {
         public static void __Register(RealStatePtr L)
         {
-			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			System.Type type = typeof(<%=CsFullTypeName(type)%>);
 			Utils.BeginObjectRegister(type, L, translator, <%=meta_func_count%>, <%=obj_method_count%>, <%=obj_getter_count%>, <%=obj_setter_count%>);
 			<%ForEachCsList(operators, function(operator)%>Utils.RegisterFunc(L, Utils.OBJ_META_IDX, "<%=(OpNameMap[operator.Name]):gsub('Meta', ''):lower()%>", <%=OpNameMap[operator.Name]%>);
@@ -166,7 +166,7 @@ namespace XLua.CSObjectWrap
             %>return LuaAPI.luaL_error(L, "<%=CsFullTypeName(type)%> does not have a constructor!");<% 
             else %>
 			try {
-                ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+                var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 				<% 
 				local hasZeroParamsCtor = false
 				ForEachCsList(constructors, function(constructor, ci)
@@ -236,7 +236,7 @@ namespace XLua.CSObjectWrap
         {
 			<%if type.IsArray then %>
 			try {
-			    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			    var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			
 				if (<%=GetCheckStatement(type, 1)%> && LuaAPI.lua_isnumber(L, 2))
 				{
@@ -252,7 +252,7 @@ namespace XLua.CSObjectWrap
 			}
 			<%elseif indexers.Count > 0 then
 			%>try {
-			    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			    var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 				<%
 					ForEachCsList(indexers, function(indexer)
 						local paramter = indexer:GetParameters()[0]
@@ -281,7 +281,7 @@ namespace XLua.CSObjectWrap
         [MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         public static int __NewIndexer(RealStatePtr L)
         {
-			<%if type.IsArray or newindexers.Count > 0 then %>ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);<%end%>
+			<%if type.IsArray or newindexers.Count > 0 then %>var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;<%end%>
 			<%if type.IsArray then 
 				local elementType = type:GetElementType()
 			%>
@@ -332,7 +332,7 @@ namespace XLua.CSObjectWrap
         {
             <% if operator.Name ~= "op_UnaryNegation" and operator.Name ~= "op_OnesComplement"  then %>
 			try {
-                ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+                var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
             <%ForEachCsList(operator.Overloads, function(overload)
                 local left_param = overload:GetParameters()[0]
                 local right_param = overload:GetParameters()[1]
@@ -354,7 +354,7 @@ namespace XLua.CSObjectWrap
 			}
             return LuaAPI.luaL_error(L, "invalid arguments to right hand of <%=OpCallNameMap[operator.Name]%> operator, need <%=CsFullTypeName(type)%>!");
             <%else%>
-			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
             try {
                 <%=GetCasterStatement(type, 1, "rightside", true)%>;
                 <%=GetPushStatement(operator.Overloads[0].ReturnType, OpCallNameMap[operator.Name] .. " rightside")%>;
@@ -375,7 +375,7 @@ namespace XLua.CSObjectWrap
             local need_obj = not method.IsStatic
             if MethodCallNeedTranslator(method) then
             %>
-                ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+                var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
             <%end%>
             <%if need_obj then%>
                 <%=GetSelfStatement(type)%>;
@@ -413,8 +413,7 @@ namespace XLua.CSObjectWrap
 					    local keyType = overload:GetParameters()[0].ParameterType
 						local valueType = overload:GetParameters()[1].ParameterType%>
 					<%=GetCasterStatement(keyType, 2, "key", true)%>;
-					<%=GetCasterStatement(valueType, 3, "gen_value", true)%>;
-                    gen_to_be_invoked[key] = gen_value;
+					<%=GetCasterStatement(valueType, 3, "gen_to_be_invoked[key]")%>;
                     <% else
                     in_pos = 0;
                     ForEachCsList(parameters, function(parameter, pi) 
@@ -480,7 +479,7 @@ namespace XLua.CSObjectWrap
         static int _g_get_<%=getter.Name%>(RealStatePtr L)
         {
 		    try {
-            <%if AccessorNeedTranslator(getter) then %>    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);<%end%>
+            <%if AccessorNeedTranslator(getter) then %>    var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;<%end%>
 			<%if not getter.IsStatic then%>
                 <%=GetSelfStatement(type)%>;
                 <%=GetPushStatement(getter.Type, "gen_to_be_invoked."..UnK(getter.Name))%>;<% else %>    <%=GetPushStatement(getter.Type, CsFullTypeName(type).."."..UnK(getter.Name))%>;<% end%>
@@ -498,7 +497,7 @@ namespace XLua.CSObjectWrap
         static int _s_set_<%=setter.Name%>(RealStatePtr L)
         {
 		    try {
-                <%if AccessorNeedTranslator(setter) then %>ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);<%end%>
+                <%if AccessorNeedTranslator(setter) then %>var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;<%end%>
 			<%if not setter.IsStatic then %>
                 <%=GetSelfStatement(type)%>;
                 <%if is_struct then %><%=GetCasterStatement(setter.Type, 2, "gen_value", true)%>;
@@ -524,7 +523,7 @@ namespace XLua.CSObjectWrap
         static int _e_<%=event.Name%>(RealStatePtr L)
         {
 		    try {
-                ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+                var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			    int gen_param_count = LuaAPI.lua_gettop(L);
 			<%=GetSelfStatement(type)%>;
                 <%=GetCasterStatement(event.Type, 3, "gen_delegate", true)%>;
@@ -560,7 +559,7 @@ namespace XLua.CSObjectWrap
         static int _e_<%=event.Name%>(RealStatePtr L)
         {
 		    try {
-                ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+                var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			    int gen_param_count = LuaAPI.lua_gettop(L);
                 <%=GetCasterStatement(event.Type, 2, "gen_delegate", true)%>;
                 if (gen_delegate == null) {

--- a/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
@@ -406,16 +406,15 @@ namespace XLua.CSObjectWrap
                     end)%>) <%end%>
                 {
                     <%if overload.Name == "get_Item" and overload.IsSpecialName then
-					    local keyType = overload:GetParameters()[0].ParameterType%>
-					<%=GetCasterStatement(keyType, 2, "key", true)%>;
-					<%=GetPushStatement(overload.ReturnType, "gen_to_be_invoked[key]")%>;
-					<%elseif overload.Name == "set_Item" and overload.IsSpecialName then
-					    local keyType = overload:GetParameters()[0].ParameterType
-						local valueType = overload:GetParameters()[1].ParameterType%>
-					<%=GetCasterStatement(keyType, 2, "key", true)%>;
-					<%=GetCasterStatement(valueType, 3, "gen_value", true)%>;						<%=GetCasterStatement(valueType, 3, "gen_to_be_invoked[key]")%>;
-                                        gen_to_be_invoked[key] = gen_value;
-					<%=GetCasterStatement(valueType, 3, "gen_to_be_invoked[key]")%>;
+                            local keyType = overload:GetParameters()[0].ParameterType%>
+                        <%=GetCasterStatement(keyType, 2, "key", true)%>;
+                        <%=GetPushStatement(overload.ReturnType, "gen_to_be_invoked[key]")%>;
+                        <%elseif overload.Name == "set_Item" and overload.IsSpecialName then
+                            local keyType = overload:GetParameters()[0].ParameterType
+                            local valueType = overload:GetParameters()[1].ParameterType%>
+                        <%=GetCasterStatement(keyType, 2, "key", true)%>;
+                        <%=GetCasterStatement(valueType, 3, "gen_value", true)%>;
+                    gen_to_be_invoked[key] = gen_value;
                     <% else
                     in_pos = 0;
                     ForEachCsList(parameters, function(parameter, pi) 

--- a/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
@@ -413,6 +413,8 @@ namespace XLua.CSObjectWrap
 					    local keyType = overload:GetParameters()[0].ParameterType
 						local valueType = overload:GetParameters()[1].ParameterType%>
 					<%=GetCasterStatement(keyType, 2, "key", true)%>;
+					<%=GetCasterStatement(valueType, 3, "gen_value", true)%>;						<%=GetCasterStatement(valueType, 3, "gen_to_be_invoked[key]")%>;
+                                        gen_to_be_invoked[key] = gen_value;
 					<%=GetCasterStatement(valueType, 3, "gen_to_be_invoked[key]")%>;
                     <% else
                     in_pos = 0;

--- a/Assets/XLua/Src/Editor/Template/LuaClassWrapGCM.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaClassWrapGCM.tpl.txt
@@ -120,7 +120,7 @@ local generic_arg_list, type_constraints = GenericArgumentList(type)
 %>
 namespace XLua
 {
-    public partial class ObjectTranslator
+    public partial class ObjectTranslatorExtensions:ObjectTranslator
     {
         public void __Register<%=v_type_name%><%=generic_arg_list%>(RealStatePtr L) <%=type_constraints%>
         {
@@ -163,7 +163,7 @@ namespace XLua
             if constructors.Count == 0 and (not type.IsValueType)  then 
             %>return LuaAPI.luaL_error(L, "<%=CsFullTypeName(type)%> does not have a constructor!");<% 
             else %>
-            ObjectTranslator translator = this;
+            ObjectTranslatorExtensions translator = this;
 			<% 
 			local hasZeroParamsCtor = false
 			ForEachCsList(constructors, function(constructor, ci)
@@ -228,7 +228,7 @@ namespace XLua
         int __CSIndexer<%=v_type_name%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
 			<%if type.IsArray then %>
-			ObjectTranslator translator = this;
+			ObjectTranslatorExtensions translator = this;
 			if (<%=GetCheckStatement(type, 1)%> && LuaAPI.lua_isnumber(L, 2))
 			{
 				int index = (int)LuaAPI.lua_tonumber(L, 2);
@@ -238,7 +238,7 @@ namespace XLua
 				return 2;
 			}
 			<%elseif indexers.Count > 0 then
-			%>ObjectTranslator translator = this;
+			%>ObjectTranslatorExtensions translator = this;
 			<%
 				ForEachCsList(indexers, function(indexer)
 					local paramter = indexer:GetParameters()[0]
@@ -262,7 +262,7 @@ namespace XLua
 		<%if type.IsArray or ((newindexers.Count or 0) > 0) then%>
         int __NewIndexer<%=v_type_name%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
-			<%if type.IsArray or newindexers.Count > 0 then %>ObjectTranslator translator = this;<%end%>
+			<%if type.IsArray or newindexers.Count > 0 then %>ObjectTranslatorExtensions translator = this;<%end%>
 			<%if type.IsArray then 
 				local elementType = type:GetElementType()
 			%>
@@ -300,7 +300,7 @@ namespace XLua
         <%ForEachCsList(operators, function(operator) %>
         int <%=v_type_name%><%=OpNameMap[operator.Name]%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
-            ObjectTranslator translator = this;
+            ObjectTranslatorExtensions translator = this;
             <% if operator.Name ~= "op_UnaryNegation" and operator.Name ~= "op_OnesComplement"  then 
                 ForEachCsList(operator.Overloads, function(overload)
                 local left_param = overload:GetParameters()[0]
@@ -332,7 +332,7 @@ namespace XLua
             local need_obj = not method.IsStatic
             if MethodCallNeedTranslator(method) then
             %>
-            ObjectTranslator translator = this;
+            ObjectTranslatorExtensions translator = this;
             <%end%>
             <%if need_obj then%>
             <%=GetSelfStatement(type)%>;
@@ -428,7 +428,7 @@ namespace XLua
         %>
         int <%=v_type_name%>_g_get_<%=getter.Name%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
-            <%if AccessorNeedTranslator(getter) then %>ObjectTranslator translator = this;<%end%>
+            <%if AccessorNeedTranslator(getter) then %>ObjectTranslatorExtensions translator = this;<%end%>
 			<%if not getter.IsStatic then%>
 			<%=GetSelfStatement(type)%>;
 			<%=GetPushStatement(getter.Type, "gen_to_be_invoked."..UnK(getter.Name))%>;<% else %>    <%=GetPushStatement(getter.Type, CsFullTypeName(type).."."..UnK(getter.Name))%>;<% end%>
@@ -441,7 +441,7 @@ namespace XLua
         %>
         int <%=v_type_name%>_s_set_<%=setter.Name%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
-            <%if AccessorNeedTranslator(setter) then %>ObjectTranslator translator = this;<%end%>
+            <%if AccessorNeedTranslator(setter) then %>ObjectTranslatorExtensions translator = this;<%end%>
 			<%if not setter.IsStatic then %>
             <%=GetSelfStatement(type)%>;
             <%if is_struct then %><%=GetCasterStatement(setter.Type, 2, "gen_value", true)%>;
@@ -462,7 +462,7 @@ namespace XLua
 		<%ForEachCsList(events, function(event) if not event.IsStatic then %>
         int <%=v_type_name%>_e_<%=event.Name%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
-            ObjectTranslator translator = this;
+            ObjectTranslatorExtensions translator = this;
 			<%=GetSelfStatement(type)%>;
 			<%=GetCasterStatement(event.Type, 3, "gen_delegate", true)%>;
 			if (gen_delegate == null) {
@@ -492,7 +492,7 @@ namespace XLua
 		<%ForEachCsList(events, function(event) if event.IsStatic then %>
         int <%=v_type_name%>_e_<%=event.Name%><%=generic_arg_list%>(RealStatePtr L, int gen_param_count) <%=type_constraints%>
         {
-            ObjectTranslator translator = this;
+            ObjectTranslatorExtensions translator = this;
 			<%=GetCasterStatement(event.Type, 2, "gen_delegate", true)%>;
 			if (gen_delegate == null) {
 				return LuaAPI.luaL_error(L, "#2 need <%=CsFullTypeName(event.Type)%>!");

--- a/Assets/XLua/Src/Editor/Template/LuaDelegateBridge.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaDelegateBridge.tpl.txt
@@ -47,7 +47,10 @@ namespace XLua
 #endif
                 RealStatePtr L = luaEnv.rawL;
                 int errFunc = LuaAPI.pcall_prepare(L, errorFuncRef, luaReference);
-                <%if CallNeedTranslator(delegate, "") then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+                <%if CallNeedTranslator(delegate, "") then %>
+                    var translator = luaEnv.translator;
+                    ObjectTranslatorExtensions translator1;
+                    <%end%>
                 <%
                 local param_count = parameters.Length
                 local has_v_params = param_count > 0 and parameters[param_count - 1].IsParamArray

--- a/Assets/XLua/Src/Editor/Template/LuaDelegateBridge.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaDelegateBridge.tpl.txt
@@ -49,7 +49,6 @@ namespace XLua
                 int errFunc = LuaAPI.pcall_prepare(L, errorFuncRef, luaReference);
                 <%if CallNeedTranslator(delegate, "") then %>
                     var translator = luaEnv.translator;
-                    ObjectTranslatorExtensions translator1;
                     <%end%>
                 <%
                 local param_count = parameters.Length

--- a/Assets/XLua/Src/Editor/Template/LuaDelegateWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaDelegateWrap.tpl.txt
@@ -27,7 +27,7 @@ namespace XLua.CSObjectWrap
     {
 		public static void __Register(RealStatePtr L)
         {
-            ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+            var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 		    Utils.BeginObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, translator, 0, 0, 0, 0);
 			Utils.EndObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, translator, null, null, null, null, null);
 			
@@ -44,7 +44,7 @@ namespace XLua.CSObjectWrap
 		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         static int __CallMeta(RealStatePtr L)
         {
-			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			try {
 				if(LuaAPI.lua_gettop(L) == <%=in_num+1%> && <%=GetCheckStatement(type, 1)%><%
 					ForEachCsList(parameters, function(parameter) 
@@ -100,7 +100,7 @@ namespace XLua.CSObjectWrap
 		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         static int __AddMeta(RealStatePtr L)
 		{
-			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			try {
 				<%=GetCasterStatement(type, 1, "leftside", true)%>;
 				<%=GetCasterStatement(type, 2, "rightside", true)%>;
@@ -114,7 +114,7 @@ namespace XLua.CSObjectWrap
 		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         static int __SubMeta(RealStatePtr L)
 		{
-			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			try {
 				<%=GetCasterStatement(type, 1, "leftside", true)%>;
 				<%=GetCasterStatement(type, 2, "rightside", true)%>;

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
@@ -19,13 +19,13 @@ namespace XLua.CSObjectWrap
 {
     using Utils = XLua.Utils;
     <%ForEachCsList(types, function(type)
-	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))		local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
-    	local fields_to_gen  = {}	
-    	ForEachCsList(fields, function(field) 	
-    	    if field.Name ~= "value__" and not IsObsolute(field) then 	
-    		    table.insert(fields_to_gen, field)	
-    		end	
-    	end)
+	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+	local fields_to_gen  = {}
+	ForEachCsList(fields, function(field) 
+	    if field.Name ~= "value__" and not IsObsolute(field) then 
+		    table.insert(fields_to_gen, field)
+		end
+	end)
 	%>
     public class <%=CSVariableName(type)%>Wrap
     {
@@ -36,15 +36,15 @@ namespace XLua.CSObjectWrap
 			Utils.EndObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, translator, null, null, null, null, null);
 			
 			Utils.BeginClassRegister(typeof(<%=CsFullTypeName(type)%>), L, null, <%=fields.Length + 1%>, 0, 0);
-			<%if #fields_to_gen <= 20 then%>
+<%if #fields_to_gen <= 20 then%>
             <% ForEachCsList(fields, function(field) 
 			if field.Name == "value__" or IsObsolute(field) then return end
 			%>
             Utils.RegisterObject(L, translator, Utils.CLS_IDX, "<%=field.Name%>", <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
             <%end)%>
-            <%else%>	
-                        Utils.RegisterEnumType(L, typeof(<%=CsFullTypeName(type)%>));	
-            <%end%>
+<%else%>
+            Utils.RegisterEnumType(L, typeof(<%=CsFullTypeName(type)%>));
+<%end%>
 			Utils.RegisterFunc(L, Utils.CLS_IDX, "__CastFrom", __CastFrom);
             
             Utils.EndClassRegister(typeof(<%=CsFullTypeName(type)%>), L, translator);
@@ -59,9 +59,10 @@ namespace XLua.CSObjectWrap
             {
                 translator.Push<%=CSVariableName(type)%>(L, (<%=CsFullTypeName(type)%>)LuaAPI.xlua_tointeger(L, 1));
             }
-			<%if  #fields_to_gen > 0 then%>
+			<%if #fields_to_gen > 0 then%>
             else if(lua_type == LuaTypes.LUA_TSTRING)
             {
+<%if #fields_to_gen <= 20 then%>
 			    <%
                 local is_first = true
 				ForEachCsList(fields, function(field, i) 
@@ -77,16 +78,16 @@ namespace XLua.CSObjectWrap
                 {
                     return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
                 }
-                <%else%>	
-                                try	
-                				{	
-                                    translator.TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);	
-                				}	
-                				catch (System.Exception e)	
-                				{	
-                					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);	
-                				}	
-                <%end%>
+<%else%>
+                try
+				{
+                    translator.TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);
+				}
+				catch (System.Exception e)
+				{
+					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);
+				}
+<%end%>
             }
 			<%end%>
             else

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
@@ -19,7 +19,13 @@ namespace XLua.CSObjectWrap
 {
     using Utils = XLua.Utils;
     <%ForEachCsList(types, function(type)
-	local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))		local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+    	local fields_to_gen  = {}	
+    	ForEachCsList(fields, function(field) 	
+    	    if field.Name ~= "value__" and not IsObsolute(field) then 	
+    		    table.insert(fields_to_gen, field)	
+    		end	
+    	end)
 	%>
     public class <%=CSVariableName(type)%>Wrap
     {
@@ -30,11 +36,15 @@ namespace XLua.CSObjectWrap
 			Utils.EndObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, translator, null, null, null, null, null);
 			
 			Utils.BeginClassRegister(typeof(<%=CsFullTypeName(type)%>), L, null, <%=fields.Length + 1%>, 0, 0);
+			<%if #fields_to_gen <= 20 then%>
             <% ForEachCsList(fields, function(field) 
 			if field.Name == "value__" or IsObsolute(field) then return end
 			%>
             Utils.RegisterObject(L, translator, Utils.CLS_IDX, "<%=field.Name%>", <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
             <%end)%>
+            <%else%>	
+                        Utils.RegisterEnumType(L, typeof(<%=CsFullTypeName(type)%>));	
+            <%end%>
 			Utils.RegisterFunc(L, Utils.CLS_IDX, "__CastFrom", __CastFrom);
             
             Utils.EndClassRegister(typeof(<%=CsFullTypeName(type)%>), L, translator);
@@ -49,7 +59,7 @@ namespace XLua.CSObjectWrap
             {
                 translator.Push<%=CSVariableName(type)%>(L, (<%=CsFullTypeName(type)%>)LuaAPI.xlua_tointeger(L, 1));
             }
-			<%if fields.Length > 0 then%>
+			<%if  #fields_to_gen > 0 then%>
             else if(lua_type == LuaTypes.LUA_TSTRING)
             {
 			    <%
@@ -67,6 +77,16 @@ namespace XLua.CSObjectWrap
                 {
                     return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
                 }
+                <%else%>	
+                                try	
+                				{	
+                                    translator.TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);	
+                				}	
+                				catch (System.Exception e)	
+                				{	
+                					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);	
+                				}	
+                <%end%>
             }
 			<%end%>
             else

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrap.tpl.txt
@@ -19,32 +19,22 @@ namespace XLua.CSObjectWrap
 {
     using Utils = XLua.Utils;
     <%ForEachCsList(types, function(type)
-	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
-	local fields_to_gen  = {}
-	ForEachCsList(fields, function(field) 
-	    if field.Name ~= "value__" and not IsObsolute(field) then 
-		    table.insert(fields_to_gen, field)
-		end
-	end)
+	local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
 	%>
     public class <%=CSVariableName(type)%>Wrap
     {
 		public static void __Register(RealStatePtr L)
         {
-		    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+		    var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 		    Utils.BeginObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, translator, 0, 0, 0, 0);
 			Utils.EndObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, translator, null, null, null, null, null);
 			
 			Utils.BeginClassRegister(typeof(<%=CsFullTypeName(type)%>), L, null, <%=fields.Length + 1%>, 0, 0);
-<%if #fields_to_gen <= 20 then%>
             <% ForEachCsList(fields, function(field) 
 			if field.Name == "value__" or IsObsolute(field) then return end
 			%>
             Utils.RegisterObject(L, translator, Utils.CLS_IDX, "<%=field.Name%>", <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
             <%end)%>
-<%else%>
-            Utils.RegisterEnumType(L, typeof(<%=CsFullTypeName(type)%>));
-<%end%>
 			Utils.RegisterFunc(L, Utils.CLS_IDX, "__CastFrom", __CastFrom);
             
             Utils.EndClassRegister(typeof(<%=CsFullTypeName(type)%>), L, translator);
@@ -53,16 +43,15 @@ namespace XLua.CSObjectWrap
 		[MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         static int __CastFrom(RealStatePtr L)
 		{
-			ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+			var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;
 			LuaTypes lua_type = LuaAPI.lua_type(L, 1);
             if (lua_type == LuaTypes.LUA_TNUMBER)
             {
                 translator.Push<%=CSVariableName(type)%>(L, (<%=CsFullTypeName(type)%>)LuaAPI.xlua_tointeger(L, 1));
             }
-			<%if #fields_to_gen > 0 then%>
+			<%if fields.Length > 0 then%>
             else if(lua_type == LuaTypes.LUA_TSTRING)
             {
-<%if #fields_to_gen <= 20 then%>
 			    <%
                 local is_first = true
 				ForEachCsList(fields, function(field, i) 
@@ -78,16 +67,6 @@ namespace XLua.CSObjectWrap
                 {
                     return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
                 }
-<%else%>
-                try
-				{
-                    translator.TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);
-				}
-				catch (System.Exception e)
-				{
-					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);
-				}
-<%end%>
             }
 			<%end%>
             else

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
@@ -17,16 +17,10 @@ local enum_or_op = debug.getmetatable(CS.System.Reflection.BindingFlags.Public).
 
 namespace XLua
 {
-	public partial class ObjectTranslator
+    public partial class ObjectTranslatorExtensions:ObjectTranslator
     {
     <%ForEachCsList(types, function(type)
-	local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
-	local fields_to_gen  = {}
-	ForEachCsList(fields, function(field) 
-	    if field.Name ~= "value__" and not IsObsolute(field) then 
-		    table.insert(fields_to_gen, field)
-		end
-	end)
+	local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
 	local v_type_name = CSVariableName(type)
 	%>
 		public void __Register<%=v_type_name%>(RealStatePtr L)
@@ -35,15 +29,11 @@ namespace XLua
 			Utils.EndObjectRegister(typeof(<%=CsFullTypeName(type)%>), L, this, null, null, null, null, null);
 			
 			Utils.BeginClassRegister(typeof(<%=CsFullTypeName(type)%>), L, null, <%=fields.Length + 1%>, 0, 0);
-<%if #fields_to_gen <= 20 then%>
             <% ForEachCsList(fields, function(field) 
 			if field.Name == "value__" or IsObsolute(field) then return end
 			%>
             Utils.RegisterObject(L, this, Utils.CLS_IDX, "<%=field.Name%>", <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
             <%end)%>
-<%else%>
-            Utils.RegisterEnumType(L, typeof(<%=CsFullTypeName(type)%>));
-<%end%>
 			Utils.RegisterFunc(L, Utils.CLS_IDX, "__CastFrom", __CastFrom<%=v_type_name%>);
             
             Utils.EndClassRegister(typeof(<%=CsFullTypeName(type)%>), L, this);
@@ -56,10 +46,9 @@ namespace XLua
             {
                 Push<%=v_type_name%>(L, (<%=CsFullTypeName(type)%>)LuaAPI.xlua_tointeger(L, 1));
             }
-			<%if #fields_to_gen > 0 then%>
+			<%if fields.Length > 0 then%>
             else if(lua_type == LuaTypes.LUA_TSTRING)
             {
-<%if #fields_to_gen <= 20 then%>
 			    <%
                 local is_first = true
 				ForEachCsList(fields, function(field, i) 
@@ -75,16 +64,6 @@ namespace XLua
                 {
                     return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
                 }
-<%else%>
-                try
-				{
-                    TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);
-				}
-				catch (System.Exception e)
-				{
-					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);
-				}
-<%end%>
             }
 			<%end%>
             else

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
@@ -20,12 +20,12 @@ namespace XLua
     public partial class ObjectTranslatorExtensions:ObjectTranslator
     {
     <%ForEachCsList(types, function(type)
-    local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))		local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
-    local fields_to_gen  = {}	
-    ForEachCsList(fields, function(field) 	
-        if field.Name ~= "value__" and not IsObsolute(field) then 	
-            table.insert(fields_to_gen, field)	
-        end	
+    local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+    	local fields_to_gen  = {}
+    	ForEachCsList(fields, function(field) 
+    	    if field.Name ~= "value__" and not IsObsolute(field) then 
+    		    table.insert(fields_to_gen, field)
+    		end
     end)
 	local v_type_name = CSVariableName(type)
 	%>
@@ -50,48 +50,49 @@ namespace XLua
 		
         int __CastFrom<%=v_type_name%>(RealStatePtr L, int __gen_top)
 		{
-			LuaTypes lua_type = LuaAPI.lua_type(L, 1);
+            LuaTypes lua_type = LuaAPI.lua_type(L, 1);
             if (lua_type == LuaTypes.LUA_TNUMBER)
             {
                 Push<%=v_type_name%>(L, (<%=CsFullTypeName(type)%>)LuaAPI.xlua_tointeger(L, 1));
             }
-			<%if #fields_to_gen > 0 then%>
+            <%if #fields_to_gen > 0 then%>
             else if(lua_type == LuaTypes.LUA_TSTRING)
             {
-			    <%
-                local is_first = true
-				ForEachCsList(fields, function(field, i) 
-			        if field.Name == "value__" or IsObsolute(field) then return end
-			    %><%=(is_first and "" or "else ")%>if (LuaAPI.xlua_is_eq_str(L, 1, "<%=field.Name%>"))
-                {
-                    Push<%=v_type_name%>(L, <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
+            <%if #fields_to_gen <= 20 then%>
+                            <%
+                            local is_first = true
+                            ForEachCsList(fields, function(field, i) 
+                                if field.Name == "value__" or IsObsolute(field) then return end
+                            %><%=(is_first and "" or "else ")%>if (LuaAPI.xlua_is_eq_str(L, 1, "<%=field.Name%>"))
+                            {
+                                Push<%=v_type_name%>(L, <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
+                            }
+                            <%
+                            is_first = false
+                            end)
+                            %>else
+                            {
+                                return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
+                            }
+            <%else%>
+                            try
+                            {
+                                TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);
+                            }
+                            catch (System.Exception e)
+                            {
+                                return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);
+                            }
+            <%end%>
+                        }
+                        <%end%>
+                        else
+                        {
+                            return LuaAPI.luaL_error(L, "invalid lua type for <%=CsFullTypeName(type)%>! Expect number or string, got + " + lua_type);
+                        }
+            
+                        return 1;
+                    }
+                <%end)%>
                 }
-				<%
-				is_first = false
-				end)
-                %>else
-                {
-                    return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
-                }
-                <%else%>	
-                                try	
-                				{	
-                                    TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);	
-                				}	
-                				catch (System.Exception e)	
-                				{	
-                					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);	
-                				}	
-                <%end%>
-            }
-			<%end%>
-            else
-            {
-                return LuaAPI.luaL_error(L, "invalid lua type for <%=CsFullTypeName(type)%>! Expect number or string, got + " + lua_type);
-            }
-
-            return 1;
-		}
-    <%end)%>
-	}
 }

--- a/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaEnumWrapGCM.tpl.txt
@@ -20,7 +20,13 @@ namespace XLua
     public partial class ObjectTranslatorExtensions:ObjectTranslator
     {
     <%ForEachCsList(types, function(type)
-	local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+    local fields = type2fields and type2fields[type] or type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))		local fields = type:GetFields(enum_or_op(CS.System.Reflection.BindingFlags.Public, CS.System.Reflection.BindingFlags.Static))
+    local fields_to_gen  = {}	
+    ForEachCsList(fields, function(field) 	
+        if field.Name ~= "value__" and not IsObsolute(field) then 	
+            table.insert(fields_to_gen, field)	
+        end	
+    end)
 	local v_type_name = CSVariableName(type)
 	%>
 		public void __Register<%=v_type_name%>(RealStatePtr L)
@@ -34,6 +40,9 @@ namespace XLua
 			%>
             Utils.RegisterObject(L, this, Utils.CLS_IDX, "<%=field.Name%>", <%=CsFullTypeName(type)%>.<%=UnK(field.Name)%>);
             <%end)%>
+            <%else%>	
+                        Utils.RegisterEnumType(L, typeof(<%=CsFullTypeName(type)%>));	
+            <%end%>
 			Utils.RegisterFunc(L, Utils.CLS_IDX, "__CastFrom", __CastFrom<%=v_type_name%>);
             
             Utils.EndClassRegister(typeof(<%=CsFullTypeName(type)%>), L, this);
@@ -46,7 +55,7 @@ namespace XLua
             {
                 Push<%=v_type_name%>(L, (<%=CsFullTypeName(type)%>)LuaAPI.xlua_tointeger(L, 1));
             }
-			<%if fields.Length > 0 then%>
+			<%if #fields_to_gen > 0 then%>
             else if(lua_type == LuaTypes.LUA_TSTRING)
             {
 			    <%
@@ -64,6 +73,16 @@ namespace XLua
                 {
                     return LuaAPI.luaL_error(L, "invalid string for <%=CsFullTypeName(type)%>!");
                 }
+                <%else%>	
+                                try	
+                				{	
+                                    TranslateToEnumToTop(L, typeof(<%=CsFullTypeName(type)%>), 1);	
+                				}	
+                				catch (System.Exception e)	
+                				{	
+                					return LuaAPI.luaL_error(L, "cast to " + typeof(<%=CsFullTypeName(type)%>) + " exception:" + e);	
+                				}	
+                <%end%>
             }
 			<%end%>
             else

--- a/Assets/XLua/Src/Editor/Template/LuaInterfaceBridge.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaInterfaceBridge.tpl.txt
@@ -57,7 +57,7 @@ namespace XLua.CSObjectWrap
 #endif
 				RealStatePtr L = luaEnv.L;
 				int err_func = LuaAPI.load_error_func(L, luaEnv.errorFuncRef);
-				<%if CallNeedTranslator(method, "") then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+				<%if CallNeedTranslator(method, "") then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 				
 				LuaAPI.lua_getref(L, luaReference);
 				LuaAPI.xlua_pushasciistring(L, "<%=method.Name%>");
@@ -116,7 +116,7 @@ namespace XLua.CSObjectWrap
 #endif
 					RealStatePtr L = luaEnv.L;
 					int oldTop = LuaAPI.lua_gettop(L);
-					<%if not JustLuaType(property.PropertyType) then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+					<%if not JustLuaType(property.PropertyType) then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 					LuaAPI.lua_getref(L, luaReference);
 					LuaAPI.xlua_pushasciistring(L, "<%=property.Name%>");
 					if (0 != LuaAPI.xlua_pgettable(L, -2))
@@ -140,7 +140,7 @@ namespace XLua.CSObjectWrap
 #endif
 					RealStatePtr L = luaEnv.L;
 					int oldTop = LuaAPI.lua_gettop(L);
-					<%if not JustLuaType(property.PropertyType) then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+					<%if not JustLuaType(property.PropertyType) then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 					LuaAPI.lua_getref(L, luaReference);
 					LuaAPI.xlua_pushasciistring(L, "<%=property.Name%>");
 					<%=GetPushStatement(property.PropertyType, "value")%>;
@@ -168,7 +168,7 @@ namespace XLua.CSObjectWrap
 #endif
 					RealStatePtr L = luaEnv.L;
 					int err_func = LuaAPI.load_error_func(L, luaEnv.errorFuncRef);
-					<%if CallNeedTranslator(event:GetAddMethod(), "") then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+					<%if CallNeedTranslator(event:GetAddMethod(), "") then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 				
 					LuaAPI.lua_getref(L, luaReference);
 					LuaAPI.xlua_pushasciistring(L, "add_<%=event.Name%>");
@@ -211,7 +211,7 @@ namespace XLua.CSObjectWrap
 #endif
 					RealStatePtr L = luaEnv.L;
 					int err_func = LuaAPI.load_error_func(L, luaEnv.errorFuncRef);
-					<%if CallNeedTranslator(event:GetRemoveMethod(), "") then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+					<%if CallNeedTranslator(event:GetRemoveMethod(), "") then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 				
 					LuaAPI.lua_getref(L, luaReference);
 					LuaAPI.xlua_pushasciistring(L, "remove_<%=event.Name%>");
@@ -272,7 +272,7 @@ namespace XLua.CSObjectWrap
 #endif
 					RealStatePtr L = luaEnv.L;
 					int err_func = LuaAPI.load_error_func(L, luaEnv.errorFuncRef);
-					<%if CallNeedTranslator(method, "") then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+					<%if CallNeedTranslator(method, "") then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 				
 					LuaAPI.lua_getref(L, luaReference);
 					LuaAPI.xlua_pushasciistring(L, "<%=method.Name%>");
@@ -335,7 +335,7 @@ namespace XLua.CSObjectWrap
 #endif
 					RealStatePtr L = luaEnv.L;
 					int err_func = LuaAPI.load_error_func(L, luaEnv.errorFuncRef);
-					<%if CallNeedTranslator(method, "") then %>ObjectTranslator translator = luaEnv.translator;<%end%>
+					<%if CallNeedTranslator(method, "") then %>var translator = luaEnv.translator as ObjectTranslatorExtensions;<%end%>
 				
 					LuaAPI.lua_getref(L, luaReference);
 					LuaAPI.xlua_pushasciistring(L, "<%=method.Name%>");

--- a/Assets/XLua/Src/Editor/Template/LuaRegister.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaRegister.tpl.txt
@@ -26,9 +26,12 @@ namespace XLua.CSObjectWrap
         local max_wrap_in_split_method = 50
         %>
         <%ForEachCsList(wraps, function(wrap)%>
-        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translator)
+        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translatorBase)
         {
+             var translator = translatorBase as ObjectTranslatorExtensions;
         <%end%>
+                       
+
             translator.DelayWrapLoader(typeof(<%=CsFullTypeName(wrap)%>), <%=CSVariableName(wrap)%>Wrap.__Register);
         <%if wrap_in_split_method == max_wrap_in_split_method then
         wrap_in_split_method = 0
@@ -50,9 +53,12 @@ namespace XLua.CSObjectWrap
         generic_arg_list = generic_arg_list .. ">"
         
         %>
-        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translator)
+        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translatorBase)
         {
+        var translator = translatorBase as ObjectTranslatorExtensions;
         <%end%>
+                    
+
             translator.DelayWrapLoader(typeof(<%=generic_def.Name:gsub("`%d+", "") .. generic_arg_list%>), <%=CSVariableName(generic_def)%>Wrap<%=generic_arg_list%>.__Register);
         <%if wrap_in_split_method == max_wrap_in_split_method then
         wrap_in_split_method = 0
@@ -70,8 +76,9 @@ namespace XLua.CSObjectWrap
         split_method_count = split_method_count + 1
         %>}<%end%>
         
-        static void Init(LuaEnv luaenv, ObjectTranslator translator)
+        static void Init(LuaEnv luaenv, ObjectTranslator translatorBase)
         {
+            var translator = translatorBase as ObjectTranslatorExtensions;
             <%for i = 1, split_method_count do%>
             <%=split_method_perfix%><%=(i - 1)%>(luaenv, translator);
             <%end%>
@@ -91,8 +98,11 @@ namespace XLua.CSObjectWrap
 }
 namespace XLua
 {
-	public partial class ObjectTranslator
+    public partial class ObjectTranslatorExtensions:ObjectTranslator
 	{
+        public ObjectTranslatorExtensions(LuaEnv luaenv, IntPtr L) : base(luaenv, L)
+        {
+        }
 		static XLua.CSObjectWrap.XLua_Gen_Initer_Register__ s_gen_reg_dumb_obj = new XLua.CSObjectWrap.XLua_Gen_Initer_Register__();
 		static XLua.CSObjectWrap.XLua_Gen_Initer_Register__ gen_reg_dumb_obj {get{return s_gen_reg_dumb_obj;}}
 	}

--- a/Assets/XLua/Src/Editor/Template/LuaRegisterGCM.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaRegisterGCM.tpl.txt
@@ -26,9 +26,12 @@ namespace XLua.CSObjectWrap
         local max_wrap_in_split_method = 50
         %>
         <%ForEachCsList(wraps, function(wrap)%>
-        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translator)
+        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translatorBase)
         {
+           var translator = translatorBase as ObjectTranslatorExtensions;
         <%end%>
+             
+
             translator.DelayWrapLoader(typeof(<%=CsFullTypeName(wrap)%>), translator.__Register<%=CSVariableName(wrap)%>);
         <%if wrap_in_split_method == max_wrap_in_split_method then
         wrap_in_split_method = 0
@@ -50,9 +53,12 @@ namespace XLua.CSObjectWrap
         generic_arg_list = generic_arg_list .. ">"
         
         %>
-        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translator)
+        <%if wrap_in_split_method == 0 then%>static void <%=split_method_perfix%><%=split_method_count%>(LuaEnv luaenv, ObjectTranslator translatorBase)
         {
+          var translator = translatorBase as ObjectTranslatorExtensions;
         <%end%>
+                      
+
             translator.DelayWrapLoader(typeof(<%=generic_def.Name:gsub("`%d+", "") .. generic_arg_list%>), translator.__Register<%=CSVariableName(generic_def)%><%=generic_arg_list%>);
         <%if wrap_in_split_method == max_wrap_in_split_method then
         wrap_in_split_method = 0
@@ -70,8 +76,9 @@ namespace XLua.CSObjectWrap
         split_method_count = split_method_count + 1
         %>}<%end%>
         
-        static void Init(LuaEnv luaenv, ObjectTranslator translator)
+        static void Init(LuaEnv luaenv, ObjectTranslator translatorBase)
         {
+        var translator = translatorBase as ObjectTranslatorExtensions;
             <%for i = 1, split_method_count do%>
             <%=split_method_perfix%><%=(i - 1)%>(luaenv, translator);
             <%end%>
@@ -91,8 +98,9 @@ namespace XLua.CSObjectWrap
 }
 namespace XLua
 {
-	public partial class ObjectTranslator
+	public partial class ObjectTranslatorExtensions:ObjectTranslator
 	{
+         
 		static XLua.CSObjectWrap.XLua_Gen_Initer_Register__ s_gen_reg_dumb_obj = new XLua.CSObjectWrap.XLua_Gen_Initer_Register__();
 		static XLua.CSObjectWrap.XLua_Gen_Initer_Register__ gen_reg_dumb_obj {get{return s_gen_reg_dumb_obj;}}
 	}

--- a/Assets/XLua/Src/Editor/Template/LuaWrapPusher.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaWrapPusher.tpl.txt
@@ -77,7 +77,7 @@ namespace XLua
 			end
 			if type_info.Flag == CS.XLua.OptimizeFlag.PackAsTable then
 			%>
-			<%if PushObjectNeedTranslator(type_info) then %>    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);<%end%>
+			<%if PushObjectNeedTranslator(type_info) then %>    var translator = ObjectTranslatorPool.Instance.Find(L) as ObjectTranslatorExtensions;<%end%>
 			LuaAPI.xlua_pushcstable(L, <%=type_info.FieldInfos.Count%>, <%=type_id_var_name%>);
 			<%ForEachCsList(type_info.FieldInfos, function(fieldInfo)%>
 			LuaAPI.xlua_pushasciistring(L, "<%=fieldInfo.Name%>");
@@ -214,8 +214,9 @@ namespace XLua
             return false;
 		}
 		
-		internal static bool __tryArraySet(Type type, RealStatePtr L, ObjectTranslator translator, object obj, int array_idx, int obj_idx)
+		internal static bool __tryArraySet(Type type, RealStatePtr L, ObjectTranslator translatorBase, object obj, int array_idx, int obj_idx)
 		{
+		var translator = translatorBase as ObjectTranslatorExtensions;
 		<%
 		local is_first = true
 		ForEachCsList(purevaluetypes, tableoptimzetypes, function(type_info)

--- a/Assets/XLua/Src/Editor/Template/LuaWrapPusher.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaWrapPusher.tpl.txt
@@ -77,6 +77,7 @@ namespace XLua
 			end
 			if type_info.Flag == CS.XLua.OptimizeFlag.PackAsTable then
 			%>
+			<%if PushObjectNeedTranslator(type_info) then %>    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);<%end%>
 			LuaAPI.xlua_pushcstable(L, <%=type_info.FieldInfos.Count%>, <%=type_id_var_name%>);
 			<%ForEachCsList(type_info.FieldInfos, function(fieldInfo)%>
 			LuaAPI.xlua_pushasciistring(L, "<%=fieldInfo.Name%>");

--- a/Assets/XLua/Src/Editor/Template/LuaWrapPusher.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaWrapPusher.tpl.txt
@@ -15,7 +15,7 @@ require "TemplateCommon"
 
 namespace XLua
 {
-    public partial class ObjectTranslator
+    public partial class ObjectTranslatorExtensions:ObjectTranslator
     {
         <%if purevaluetypes.Count > 0 then
         local init_class_name = "IniterAdder" .. CSVariableName(purevaluetypes[0].Type)
@@ -27,8 +27,9 @@ namespace XLua
                 LuaEnv.AddIniter(Init);
             }
 			
-			static void Init(LuaEnv luaenv, ObjectTranslator translator)
+			static void Init(LuaEnv luaenv, ObjectTranslator translatorBase)
 			{
+			var translator = translatorBase as ObjectTranslatorExtensions;
 			<%ForEachCsList(purevaluetypes, function(type_info)
             if not type_info.Type.IsValueType then return end
             local full_type_name = CsFullTypeName(type_info.Type)%>
@@ -76,7 +77,6 @@ namespace XLua
 			end
 			if type_info.Flag == CS.XLua.OptimizeFlag.PackAsTable then
 			%>
-			<%if PushObjectNeedTranslator(type_info) then %>    ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);<%end%>
 			LuaAPI.xlua_pushcstable(L, <%=type_info.FieldInfos.Count%>, <%=type_id_var_name%>);
 			<%ForEachCsList(type_info.FieldInfos, function(fieldInfo)%>
 			LuaAPI.xlua_pushasciistring(L, "<%=fieldInfo.Name%>");
@@ -196,8 +196,9 @@ namespace XLua
 	
 	public partial class StaticLuaCallbacks
     {
-	    internal static bool __tryArrayGet(Type type, RealStatePtr L, ObjectTranslator translator, object obj, int index)
+	    internal static bool __tryArrayGet(Type type, RealStatePtr L, ObjectTranslator translatorBase, object obj, int index)
 		{
+		var translator = translatorBase as ObjectTranslatorExtensions;
 		<%ForEachCsList(purevaluetypes, function(type_info, idx)
 		if not type_info.Type.IsValueType then return end
 		local full_type_name = CsFullTypeName(type_info.Type)

--- a/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
+++ b/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
@@ -210,14 +210,8 @@ local function _CsFullTypeName(t)
 end
 
 function CsFullTypeName(t)
-    if t.DeclaringType then
-        local name = _CsFullTypeName(t)
-        local declaringTypeName = _CsFullTypeName(t.DeclaringType);
-        return xLuaClasses[declaringTypeName] and ("global::" .. name) or name
-    else
-        local name = _CsFullTypeName(t)
-        return xLuaClasses[name] and ("global::" .. name) or name
-    end
+    local name = _CsFullTypeName(t)
+	return xLuaClasses[name] and ("global::" .. name) or name
 end
 
 function CSVariableName(t)
@@ -375,13 +369,14 @@ function GetPushStatement(t, variable, is_v_params)
     if fixPush[testname] then
         return fixPush[testname] .. "(L, ".. variable ..")" 
     elseif genPushAndUpdateTypes[t] then
-        return "translator.Push".. CSVariableName(t) .."(L, "..variable..")"
+        return 
+        "if((translator as ObjectTranslatorExtensions) != null)\n        {\n            (translator as ObjectTranslatorExtensions).Push".. CSVariableName(t) .."(L, "..variable..");\n        }"
     elseif t.IsGenericParameter and not t.DeclaringMethod then
-	    return "translator.PushByType(L, "..variable..")"
-	elseif t.IsInterface or GetNullableUnderlyingType(t) then
-	    return "translator.PushAny(L, "..variable..")"
+	    return "if((translator as ObjectTranslatorExtensions) != null)\n        {\n            (translator as ObjectTranslatorExtensions).PushByType(L, "..variable..");\n        }\n        else\n        translator.PushByType(L, "..variable..")"
+    elseif t.IsInterface or GetNullableUnderlyingType(t) then
+	    return "if((translator as ObjectTranslatorExtensions) != null)\n        {\n            (translator as ObjectTranslatorExtensions).PushAny(L, "..variable..");\n        }\n        else\n        translator.PushAny(L, "..variable..")"
     else
-        return "translator.Push(L, "..variable..")"
+        return "if((translator as ObjectTranslatorExtensions) != null)\n        {\n            (translator as ObjectTranslatorExtensions).Push(L, "..variable..");\n        }\n        else\n        translator.Push(L, "..variable..")"
     end
 end
 
@@ -415,10 +410,6 @@ end
 
 function AccessorNeedTranslator(accessor)
     return not accessor.IsStatic or not JustLuaType(accessor.Type)
-end
-
-function PushObjectNeedTranslator(type_info)
-    return IfAny(type_info.FieldInfos, function(field_info) return not JustLuaType(field_info.Type) end)
 end
 
 local GenericParameterAttributes = CS.System.Reflection.GenericParameterAttributes

--- a/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
+++ b/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
@@ -184,24 +184,24 @@ local valueType = typeof(CS.System.ValueType)
 
 local function _CsFullTypeName(t)
     if t.IsArray then
-	    local element_name, element_is_array = _CsFullTypeName(t:GetElementType())
-		if element_is_array then
-		    local bracket_pos = element_name:find('%[')
-			return element_name:sub(1, bracket_pos - 1) .. '[' .. string.rep(',', t:GetArrayRank() - 1) .. ']' .. element_name:sub(bracket_pos, -1), true
-		else
+        local element_name, element_is_array = _CsFullTypeName(t:GetElementType())
+        if element_is_array then
+            local bracket_pos = element_name:find('%[')
+            return element_name:sub(1, bracket_pos - 1) .. '[' .. string.rep(',', t:GetArrayRank() - 1) .. ']' .. element_name:sub(bracket_pos, -1), true
+        else
             return element_name .. '[' .. string.rep(',', t:GetArrayRank() - 1) .. ']', true
-	    end
+        end
     elseif t.IsByRef then
         return _CsFullTypeName(t:GetElementType())
     elseif t.IsGenericParameter then
         return (t.BaseType == objType or t.BaseType == valueType) and t.Name or _CsFullTypeName(t.BaseType) --TODO:应该判断是否类型约束
     end
 
-    local name = t.FullName:gsub("&", ""):gsub("%+", ".") 
-    if not t.IsGenericType then 
+    local name = t.FullName:gsub("&", ""):gsub("%+", ".")
+    if not t.IsGenericType then
         return friendlyNameMap[name] or name
     end
-	local genericParameter = ""
+    local genericParameter = ""
     ForEachCsList(t:GetGenericArguments(), function(at, ati)
         if ati ~= 0 then  genericParameter = genericParameter .. ', ' end
         genericParameter = genericParameter .. _CsFullTypeName(at)
@@ -210,8 +210,8 @@ local function _CsFullTypeName(t)
 end
 
 function CsFullTypeName(t)
-    if t.DeclaringType then	    local name = _CsFullTypeName(t)
-        local name = _CsFullTypeName(t)		return xLuaClasses[name] and ("global::" .. name) or name
+    if t.DeclaringType then
+        local name = _CsFullTypeName(t)
         local declaringTypeName = _CsFullTypeName(t.DeclaringType);
         return xLuaClasses[declaringTypeName] and ("global::" .. name) or name
     else

--- a/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
+++ b/Assets/XLua/Src/Editor/Template/TemplateCommon.lua.txt
@@ -210,8 +210,14 @@ local function _CsFullTypeName(t)
 end
 
 function CsFullTypeName(t)
-    local name = _CsFullTypeName(t)
-	return xLuaClasses[name] and ("global::" .. name) or name
+    if t.DeclaringType then	    local name = _CsFullTypeName(t)
+        local name = _CsFullTypeName(t)		return xLuaClasses[name] and ("global::" .. name) or name
+        local declaringTypeName = _CsFullTypeName(t.DeclaringType);
+        return xLuaClasses[declaringTypeName] and ("global::" .. name) or name
+    else
+        local name = _CsFullTypeName(t)
+        return xLuaClasses[name] and ("global::" .. name) or name
+    end
 end
 
 function CSVariableName(t)
@@ -410,6 +416,10 @@ end
 
 function AccessorNeedTranslator(accessor)
     return not accessor.IsStatic or not JustLuaType(accessor.Type)
+end
+
+function PushObjectNeedTranslator(type_info)
+    return IfAny(type_info.FieldInfos, function(field_info) return not JustLuaType(field_info.Type) end)
 end
 
 local GenericParameterAttributes = CS.System.Reflection.GenericParameterAttributes

--- a/Assets/XLua/Src/LuaEnv.cs
+++ b/Assets/XLua/Src/LuaEnv.cs
@@ -15,8 +15,9 @@ using LuaAPI = XLua.LuaDLL.Lua;
 using RealStatePtr = System.IntPtr;
 using LuaCSFunction = XLua.LuaDLL.lua_CSFunction;
 #endif
+#if UNITY_EDITOR
 using UnityEngine;
-
+#endif
 
 namespace XLua
 {
@@ -85,6 +86,7 @@ namespace XLua
                 LuaAPI.luaopen_xlua(rawL);
                 LuaAPI.luaopen_i64lib(rawL);
 
+#if UNITY_EDITOR
                 if (CreateObjectTranslatorDelegate != null)
                     translator = CreateObjectTranslatorDelegate(this, rawL);
                 else
@@ -96,6 +98,9 @@ namespace XLua
                         translator = new ObjectTranslator(this, rawL);
                     }
                 }
+#else
+                translator = new ObjectTranslator(this, rawL);
+#endif
                 translator.createFunctionMetatable(rawL);
                 translator.OpenLib(rawL);
                 ObjectTranslatorPool.Instance.Add(rawL, translator);

--- a/Assets/XLua/Src/LuaEnv.cs
+++ b/Assets/XLua/Src/LuaEnv.cs
@@ -15,7 +15,7 @@ using LuaAPI = XLua.LuaDLL.Lua;
 using RealStatePtr = System.IntPtr;
 using LuaCSFunction = XLua.LuaDLL.lua_CSFunction;
 #endif
-#if UNITY_EDITOR
+#if !XLUA_GENERAL
 using UnityEngine;
 #endif
 
@@ -86,7 +86,7 @@ namespace XLua
                 LuaAPI.luaopen_xlua(rawL);
                 LuaAPI.luaopen_i64lib(rawL);
 
-#if UNITY_EDITOR
+#if !XLUA_GENERAL
                 if (CreateObjectTranslatorDelegate != null)
                     translator = CreateObjectTranslatorDelegate(this, rawL);
                 else

--- a/Assets/XLua/Src/ObjectTranslator.cs
+++ b/Assets/XLua/Src/ObjectTranslator.cs
@@ -102,7 +102,7 @@ namespace XLua
     public delegate int CSharpWrapper(IntPtr L, int top);
 #endif
 
-    public partial class ObjectTranslator
+    public class ObjectTranslator
 	{
         internal MethodWrapsCache methodWrapsCache;
         internal ObjectCheckers objectCheckers;

--- a/Assets/XLua/Tutorial/CSharpCallLua/CSCallLua.cs
+++ b/Assets/XLua/Tutorial/CSharpCallLua/CSCallLua.cs
@@ -69,7 +69,11 @@ namespace Tutorial
         // Use this for initialization
         void Start()
         {
+            var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+            var go = Instantiate(prefab);
+            
             luaenv = new LuaEnv();
+            
             luaenv.DoString(script);
 
             Debug.Log("_G.a = " + luaenv.Global.Get<int>("a"));

--- a/Assets/XLua/Tutorial/LoadLuaScript/ByFile/ByFile.cs
+++ b/Assets/XLua/Tutorial/LoadLuaScript/ByFile/ByFile.cs
@@ -18,6 +18,8 @@ namespace Tutorial
         // Use this for initialization
         void Start()
         {
+            var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+            var go = Instantiate(prefab);
             luaenv = new LuaEnv();
             luaenv.DoString("require 'byfile'");
         }

--- a/Assets/XLua/Tutorial/LoadLuaScript/ByString/ByString.cs
+++ b/Assets/XLua/Tutorial/LoadLuaScript/ByString/ByString.cs
@@ -18,6 +18,8 @@ namespace Tutorial
         // Use this for initialization
         void Start()
         {
+            var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+            var go = Instantiate(prefab);
             luaenv = new LuaEnv();
             luaenv.DoString("print('hello world')");
         }

--- a/Assets/XLua/Tutorial/LoadLuaScript/Loader/CustomLoader.cs
+++ b/Assets/XLua/Tutorial/LoadLuaScript/Loader/CustomLoader.cs
@@ -18,6 +18,8 @@ namespace Tutorial
         // Use this for initialization
         void Start()
         {
+            var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+            var go = Instantiate(prefab);
             luaenv = new LuaEnv();
             luaenv.AddLoader((ref string filename) =>
             {

--- a/Assets/XLua/Tutorial/LuaCallCSharp/LuaCallCs.cs
+++ b/Assets/XLua/Tutorial/LuaCallCSharp/LuaCallCs.cs
@@ -295,6 +295,9 @@ public class LuaCallCs : MonoBehaviour
 	// Use this for initialization
 	void Start()
 	{
+		var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+		var go = Instantiate(prefab);
+		
 		luaenv = new LuaEnv();
 		luaenv.DoString(script);
 	}

--- a/Test/UnitTest/xLuaTest/Main.cs
+++ b/Test/UnitTest/xLuaTest/Main.cs
@@ -5,6 +5,19 @@ using XLua;
 
 public class Main : MonoBehaviour {
 	LuaEnv luaenv;
+
+	void Awake(){
+		 var prefab = Resources.Load<GameObject>("LuaEnvStarter");
+            if (prefab)
+            {
+                var go = Instantiate(prefab);
+
+            }
+            else
+            {
+                Debug.LogError("Not generate wraps");
+            }
+	}
 	// Use this for initialization
 	void Start () {
 		luaenv = LuaEnvSingleton.Instance;


### PR DESCRIPTION
1. 使用了继承的方式来扩展ObjectTranslator
2. 通过Generator命令生成一个prefab，这个prefab挂载的脚本处理了从Assembly-Csharp中创建ObjectTranslatorExtensions的逻辑