### PR TITLE
Lua CS Function

### DIFF
--- a/Assets/XLua/Examples/14_LuaCSFunction.meta
+++ b/Assets/XLua/Examples/14_LuaCSFunction.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5217e99bed1ba374584cfc041e6d3465
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunction.unity
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunction.unity
@@ -1,0 +1,166 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &1665434191
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1665434192}
+  - component: {fileID: 1665434193}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1665434192
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665434191}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1665434193
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1665434191}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 618d9490206633449b1924ec4cb52437, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunction.unity.meta
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunction.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: effdee24faca71148b335c51cb9c7ca0
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
@@ -17,8 +17,13 @@ namespace XLuaTest
                 CS.XLuaTest.LuaCSFunc_GenCode.DebugLog('gencode static call')
                 CS.XLuaTest.LuaCSFunc_Reflection():MemberCall('reflection member call')
                 CS.XLuaTest.LuaCSFunc_GenCode():MemberCall('gencode member call')
+                
+
             ";
             luaenv.DoString(lua);
+            //定义 LUACSFUNC_TRY_CATCH 宏，打印lua栈
+            luaenv.DoString("CS.XLuaTest.LuaCSFunction_TryCatch.DebugLog('Error static call')");
+            luaenv.DoString("CS.XLuaTest.LuaCSFunction_TryCatch():MemberCall('Error member call')");
         }
 
     }
@@ -62,6 +67,28 @@ namespace XLuaTest
         {
             var str = LuaAPI.lua_tostring(L, 1);
             Debug.Log(name+":"+str);
+            return 0;
+        }
+    }
+
+    [LuaCallCSharp]
+    public class LuaCSFunction_TryCatch
+    {
+        string name = "LuaCSFunc_TryCatch";
+
+        [LuaCSFunction]
+        public static int DebugLog(IntPtr L)
+        {
+            var str = LuaAPI.lua_tostring(L, 1);
+            throw new Exception(str);
+            return 0;
+        }
+
+        [LuaCSFunction]
+        public int MemberCall(IntPtr L)
+        {
+            var str = LuaAPI.lua_tostring(L, 1);
+            throw new Exception(name + ":" + str);
             return 0;
         }
     }

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
@@ -17,13 +17,12 @@ namespace XLuaTest
                 CS.XLuaTest.LuaCSFunc_GenCode.DebugLog('gencode static call')
                 CS.XLuaTest.LuaCSFunc_Reflection():MemberCall('reflection member call')
                 CS.XLuaTest.LuaCSFunc_GenCode():MemberCall('gencode member call')
-                
-
             ";
             luaenv.DoString(lua);
-            //定义 LUACSFUNC_TRY_CATCH 宏，打印lua栈
-            luaenv.DoString("CS.XLuaTest.LuaCSFunction_TryCatch.DebugLog('Error static call')");
+            //定义 LUACSFUNC_TRY_CATCH 宏，Catch错误并打印lua栈
             luaenv.DoString("CS.XLuaTest.LuaCSFunction_TryCatch():MemberCall('Error member call')");
+            luaenv.DoString("CS.XLuaTest.LuaCSFunction_TryCatch.DebugLog('Error static call')");
+
         }
 
     }
@@ -81,7 +80,6 @@ namespace XLuaTest
         {
             var str = LuaAPI.lua_tostring(L, 1);
             throw new Exception(str);
-            return 0;
         }
 
         [LuaCSFunction]
@@ -89,7 +87,6 @@ namespace XLuaTest
         {
             var str = LuaAPI.lua_tostring(L, 1);
             throw new Exception(name + ":" + str);
-            return 0;
         }
     }
 }

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
@@ -14,9 +14,12 @@ namespace XLuaTest
             LuaEnv luaenv = new LuaEnv();
             string lua = @"
                 CS.XLuaTest.LuaCSFunc_Reflection.DebugLog('reflection static call')
-                CS.XLuaTest.LuaCSFunc_GenCode.DebugLog('gencode static call')
                 CS.XLuaTest.LuaCSFunc_Reflection():MemberCall('reflection member call')
+                CS.XLuaTest.LuaCSFunc_Reflection():ExLog('reflection ex call')
+                CS.XLuaTest.LuaCSFunc_GenCode.DebugLog('gencode static call')
                 CS.XLuaTest.LuaCSFunc_GenCode():MemberCall('gencode member call')
+                CS.XLuaTest.LuaCSFunc_GenCode():MemberCall('gencode ex call')
+
             ";
             luaenv.DoString(lua);
             //定义 LUACSFUNC_TRY_CATCH 宏，Catch错误并打印lua栈
@@ -26,8 +29,7 @@ namespace XLuaTest
         }
 
     }
-    
-    class LuaCSFunc_Reflection
+    public class LuaCSFunc_Reflection
     {
         string name = "LuaCSFunc_Reflection";
 
@@ -89,4 +91,21 @@ namespace XLuaTest
             throw new Exception(name + ":" + str);
         }
     }
+
+    [LuaCallCSharp]
+    public static class Extension
+    {
+        [LuaCSFunction]
+        public static int ExLog(this LuaCSFunc_GenCode obj, IntPtr L)
+        {
+            return obj.MemberCall(L);
+        }
+
+        [LuaCSFunction]
+        public static int ExLog(this LuaCSFunc_Reflection obj, IntPtr L)
+        {
+            return obj.MemberCall(L);
+        }
+    }
+
 }

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using XLua;
+using LuaAPI = XLua.LuaDLL.Lua;
+namespace XLuaTest
+{
+    public class LuaCSFunctionExample : MonoBehaviour
+    {
+        // Start is called before the first frame update
+        void Start()
+        {
+            LuaEnv luaenv = new LuaEnv();
+            string lua = @"
+                CS.XLuaTest.LuaCSFunc_Reflection.DebugLog('reflection static call')
+                CS.XLuaTest.LuaCSFunc_GenCode.DebugLog('gencode static call')
+                CS.XLuaTest.LuaCSFunc_Reflection():MemberCall('reflection member call')
+                CS.XLuaTest.LuaCSFunc_GenCode():MemberCall('gencode member call')
+            ";
+            luaenv.DoString(lua);
+        }
+
+    }
+    
+    class LuaCSFunc_Reflection
+    {
+        string name = "LuaCSFunc_Reflection";
+
+        [LuaCSFunction]
+        public static int DebugLog(IntPtr L)
+        {
+            var str = LuaAPI.lua_tostring(L, 1);
+            Debug.Log(str);
+            return 0;
+        }
+
+        [LuaCSFunction]
+        public int MemberCall(IntPtr L)
+        {
+            var str = LuaAPI.lua_tostring(L, 1);
+            Debug.Log(name + ":" + str);
+            return 0;
+        }
+    }
+
+    [LuaCallCSharp]
+    public class LuaCSFunc_GenCode
+    {
+        string name = "LuaCSFunc_GenCode";
+
+        [LuaCSFunction]
+        public static int DebugLog(IntPtr L)
+        {
+            var str = LuaAPI.lua_tostring(L, 1);
+            Debug.Log(str);
+            return 0;
+        }
+
+        [LuaCSFunction]
+        public int MemberCall(IntPtr L)
+        {
+            var str = LuaAPI.lua_tostring(L, 1);
+            Debug.Log(name+":"+str);
+            return 0;
+        }
+    }
+}

--- a/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs.meta
+++ b/Assets/XLua/Examples/14_LuaCSFunction/LuaCSFunctionExample.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 618d9490206633449b1924ec4cb52437
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/XLua/Src/CodeEmit.cs
+++ b/Assets/XLua/Src/CodeEmit.cs
@@ -1612,9 +1612,6 @@ namespace XLua
             LocalBuilder wrapRet = il.DeclareLocal(typeof(int));
             LocalBuilder ex = il.DeclareLocal(typeof(Exception));
             Label retPoint = il.DefineLabel();
-#else 
-            //CustomAttributeBuilder cab = new CustomAttributeBuilder(typeof(MonoPInvokeCallbackAttribute).GetConstructor(new Type[]{typeof(Type)}),new object[]{ typeof(LuaCSFunction) });
-            //methodBuilder.SetCustomAttribute(cab);
 #endif
             LocalBuilder L = il.DeclareLocal(typeof(RealStatePtr));
             il.Emit(OpCodes.Ldarg_0);

--- a/Assets/XLua/Src/CodeEmit.cs
+++ b/Assets/XLua/Src/CodeEmit.cs
@@ -1597,7 +1597,7 @@ namespace XLua
             var paramInfos = method.GetParameters();
             bool needObj = false;
             Type objType = null;
-            if (method.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute)))
+            if (Utils.IsDefined(method, typeof(System.Runtime.CompilerServices.ExtensionAttribute)))
             {
                 needObj = true;
                 objType = declaringType;
@@ -1666,7 +1666,7 @@ namespace XLua
             for (int i = 0; i < methodsToCall.Count; i++)
             {
                 var method = methodsToCall[i];
-                if (method.IsDefined(typeof(LuaCSFunctionAttribute)))
+                if (Utils.IsDefined(method, typeof(LuaCSFunctionAttribute)))
                 {
                     if (methodsToCall.Count > 1)
                     {

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -1606,7 +1606,7 @@ namespace CSObjectWrapEditor
 #if XLUA_GENERAL
         static bool IsExtensionMethod(MethodInfo method)
         {
-            return isDefined(method, typeof(ExtensionAttribute));
+            return Utils.IsDefined(method, typeof(ExtensionAttribute));
         }
 
         static bool IsDelegate(Type type)

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -190,7 +190,7 @@ namespace CSObjectWrapEditor
 
                 type_has_extension_methods = from type in gen_types
                                              where type.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                                                    .Any(method => isDefined(method, typeof(ExtensionAttribute)))
+                                                    .Any(method => Utils.IsDefined(method, typeof(ExtensionAttribute)))
                                              select type;
             }
             return from type in type_has_extension_methods
@@ -202,7 +202,7 @@ namespace CSObjectWrapEditor
 
         static bool isSupportedExtensionMethod(MethodBase method, Type extendedType)
         {
-            if (!isDefined(method, typeof(ExtensionAttribute)))
+            if (!Utils.IsDefined(method, typeof(ExtensionAttribute)))
                 return false;
             var methodParameters = method.GetParameters();
             if (methodParameters.Length < 1)
@@ -252,7 +252,7 @@ namespace CSObjectWrapEditor
         {
             return DoNotGen.ContainsKey(type) && DoNotGen[type].Contains(name);
         }
-
+        
         static void getClassInfo(Type type, LuaTable parameters)
         {
             parameters.Set("type", type);
@@ -305,7 +305,7 @@ namespace CSObjectWrapEditor
 
             //warnning: filter all method start with "op_"  "add_" "remove_" may  filter some ordinary method
             parameters.Set("methods", type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.IgnoreCase | BindingFlags.DeclaredOnly)
-                .Where(method => !isDefined(method, typeof (ExtensionAttribute)) || method.GetParameters()[0].ParameterType.IsInterface || method.DeclaringType != type)
+                .Where(method => !Utils.IsDefined(method, typeof (ExtensionAttribute)) || method.GetParameters()[0].ParameterType.IsInterface || method.DeclaringType != type)
                 .Where(method => !method.IsSpecialName 
                     || (
                          ((method.Name == "get_Item" && method.GetParameters().Length == 1) || (method.Name == "set_Item" && method.GetParameters().Length == 2)) 
@@ -315,7 +315,7 @@ namespace CSObjectWrapEditor
                 .Concat(extension_methods)
                 .Where(method => !IsDoNotGen(type, method.Name))
                 .Where(method => !isMethodInBlackList(method) && (!method.IsGenericMethod || extension_methods.Contains(method) || isSupportedGenericMethod(method)) && !isObsolete(method))
-                .GroupBy(method => (method.Name + ((method.IsStatic && (!isDefined(method, typeof (ExtensionAttribute)) || method.GetParameters()[0].ParameterType.IsInterface)) ? "_xlua_st_" : "")), (k, v) =>
+                .GroupBy(method => (method.Name + ((method.IsStatic && (!Utils.IsDefined(method, typeof (ExtensionAttribute)) || method.GetParameters()[0].ParameterType.IsInterface)) ? "_xlua_st_" : "")), (k, v) =>
                 {
                     var overloads = new List<MethodBase>();
                     List<int> def_vals = new List<int>();
@@ -323,7 +323,7 @@ namespace CSObjectWrapEditor
                     bool isLuaCSFunc = false;
                     foreach (var overload in v.Cast<MethodBase>().OrderBy(mb => OverloadCosting(mb)))
                     {
-                        if(overload.IsDefined(typeof(LuaCSFunctionAttribute)))
+                        if(Utils.IsDefined(overload,typeof(LuaCSFunctionAttribute)))
                         {
                             isLuaCSFunc = true;
                             overloads.Clear();
@@ -358,7 +358,7 @@ namespace CSObjectWrapEditor
                     return new
                     {
                         Name = k,
-                        IsStatic = overloads[0].IsStatic && (!isDefined(overloads[0], typeof(ExtensionAttribute)) || overloads[0].GetParameters()[0].ParameterType.IsInterface),
+                        IsStatic = overloads[0].IsStatic && (!Utils.IsDefined(overloads[0], typeof(ExtensionAttribute)) || overloads[0].GetParameters()[0].ParameterType.IsInterface),
                         Overloads = overloads,
                         DefaultValues = def_vals,
                         IsLuaCSFunc = isLuaCSFunc,
@@ -532,7 +532,7 @@ namespace CSObjectWrapEditor
 
         static bool isMemberInBlackList(MemberInfo mb)
         {
-            if (isDefined(mb, typeof(BlackListAttribute))) return true;
+            if (Utils.IsDefined(mb, typeof(BlackListAttribute))) return true;
             if (mb is FieldInfo && (mb as FieldInfo).FieldType.IsPointer) return true;
             if (mb is PropertyInfo && (mb as PropertyInfo).PropertyType.IsPointer) return true;
 
@@ -557,7 +557,7 @@ namespace CSObjectWrapEditor
 
         static bool isMethodInBlackList(MethodBase mb)
         {
-            if (isDefined(mb, typeof(BlackListAttribute))) return true;
+            if (Utils.IsDefined(mb, typeof(BlackListAttribute))) return true;
 
             //指针目前不支持，先过滤
             if (mb.GetParameters().Any(pInfo => pInfo.ParameterType.IsPointer)) return true;
@@ -919,7 +919,7 @@ namespace CSObjectWrapEditor
 
             var bindingAttrOfMethod = BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static | BindingFlags.DeclaredOnly | BindingFlags.NonPublic;
             var bindingAttrOfConstructor = BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly | BindingFlags.NonPublic;
-            foreach (var type in (from type in hotfix_check_types where isDefined(type, typeof(HotfixAttribute)) select type))
+            foreach (var type in (from type in hotfix_check_types where Utils.IsDefined(type, typeof(HotfixAttribute)) select type))
             {
                 var ca = GetCustomAttribute(type, typeof(HotfixAttribute));
 #if XLUA_GENERAL
@@ -938,7 +938,7 @@ namespace CSObjectWrapEditor
                 bool ignoreProperty = kv.Value.HasFlag(HotfixFlag.IgnoreProperty);
                 bool ignoreNotPublic = kv.Value.HasFlag(HotfixFlag.IgnoreNotPublic);
                 bool ignoreCompilerGenerated = kv.Value.HasFlag(HotfixFlag.IgnoreCompilerGenerated);
-                if (ignoreCompilerGenerated && isDefined(kv.Key, typeof(CompilerGeneratedAttribute)))
+                if (ignoreCompilerGenerated && Utils.IsDefined(kv.Key, typeof(CompilerGeneratedAttribute)))
                 {
                     continue;
                 }
@@ -946,7 +946,7 @@ namespace CSObjectWrapEditor
                 hotfxDelegates.AddRange(kv.Key.GetMethods(bindingAttrOfMethod)
                     .Where(method => method.GetMethodBody() != null)
                     .Where(method => !method.Name.Contains("<"))
-                    .Where(method => !ignoreCompilerGenerated || !isDefined(method, typeof(CompilerGeneratedAttribute)))
+                    .Where(method => !ignoreCompilerGenerated || !Utils.IsDefined(method, typeof(CompilerGeneratedAttribute)))
                     .Where(method => !ignoreNotPublic || method.IsPublic)
                     .Where(method => !ignoreProperty || !method.IsSpecialName || (!method.Name.StartsWith("get_") && !method.Name.StartsWith("set_")))
                     .Cast<MethodBase>()
@@ -1128,17 +1128,17 @@ namespace CSObjectWrapEditor
             var lookup = LuaCallCSharp.Distinct().ToDictionary(t => t);
 
             var extension_methods_from_lcs = (from t in LuaCallCSharp
-                                    where isDefined(t, typeof(ExtensionAttribute))
+                                    where Utils.IsDefined(t, typeof(ExtensionAttribute))
                                     from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                                    where isDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
+                                    where Utils.IsDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
                                     where !method.ContainsGenericParameters || isSupportedGenericMethod(method)
                                     select makeGenericMethodIfNeeded(method))
                                     .Where(method => !lookup.ContainsKey(method.GetParameters()[0].ParameterType));
 
             var extension_methods = (from t in ReflectionUse
-                                     where isDefined(t, typeof(ExtensionAttribute))
+                                     where Utils.IsDefined(t, typeof(ExtensionAttribute))
                                      from method in t.GetMethods(BindingFlags.Static | BindingFlags.Public)
-                                     where isDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
+                                     where Utils.IsDefined(method, typeof(ExtensionAttribute)) && !isObsolete(method)
                                      where !method.ContainsGenericParameters || isSupportedGenericMethod(method)
                                      select makeGenericMethodIfNeeded(method)).Concat(extension_methods_from_lcs);
             GenOne(typeof(DelegateBridgeBase), (type, type_info) =>
@@ -1185,7 +1185,7 @@ namespace CSObjectWrapEditor
                 foreach(var propInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
                     if ((AdditionalProperties.ContainsKey(type) && AdditionalProperties[type].Contains(propInfo.Name))
-                        || isDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
+                        || Utils.IsDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
                     {
                         AllSubStruct(propInfo.PropertyType, cb);
                     }
@@ -1216,7 +1216,7 @@ namespace CSObjectWrapEditor
                         .Concat(t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
                         .Where(prop => {
                             return (AdditionalProperties.ContainsKey(t) && AdditionalProperties[t].Contains(prop.Name))
-                                || isDefined(prop, typeof(AdditionalPropertiesAttribute));
+                                || Utils.IsDefined(prop, typeof(AdditionalPropertiesAttribute));
                         })
                         .Select(prop => new XluaFieldInfo { Name = prop.Name, Type = prop.PropertyType, IsField = false, Size = SizeOf(prop.PropertyType) }));
             int float_field_count = 0;
@@ -1338,15 +1338,6 @@ namespace CSObjectWrapEditor
             }
         }
 
-        static bool isDefined(MemberInfo test, Type type)
-        {
-#if XLUA_GENERAL
-            return test.GetCustomAttributes(false).Any(ca => ca.GetType().ToString() == type.ToString());
-#else
-            return test.IsDefined(type, false);
-#endif
-        }
-
         static object GetCustomAttribute(MemberInfo test, Type type)
         {
 #if XLUA_GENERAL
@@ -1358,7 +1349,7 @@ namespace CSObjectWrapEditor
 
         static void MergeCfg(MemberInfo test, Type cfg_type, Func<object> get_cfg)
         {
-            if (isDefined(test, typeof(LuaCallCSharpAttribute)))
+            if (Utils.IsDefined(test, typeof(LuaCallCSharpAttribute)))
             {
                 object ccla = GetCustomAttribute(test, typeof(LuaCallCSharpAttribute));
                 AddToList(LuaCallCSharp, get_cfg, ccla);
@@ -1371,20 +1362,20 @@ namespace CSObjectWrapEditor
                 }
 #endif
             }
-            if (isDefined(test, typeof(CSharpCallLuaAttribute)))
+            if (Utils.IsDefined(test, typeof(CSharpCallLuaAttribute)))
             {
                 AddToList(CSharpCallLua, get_cfg, GetCustomAttribute(test, typeof(CSharpCallLuaAttribute)));
             }
-            if (isDefined(test, typeof(GCOptimizeAttribute)))
+            if (Utils.IsDefined(test, typeof(GCOptimizeAttribute)))
             {
                 AddToList(GCOptimizeList, get_cfg, GetCustomAttribute(test, typeof(GCOptimizeAttribute)));
             }
-            if (isDefined(test, typeof(ReflectionUseAttribute)))
+            if (Utils.IsDefined(test, typeof(ReflectionUseAttribute)))
             {
                 AddToList(ReflectionUse, get_cfg, GetCustomAttribute(test, typeof(ReflectionUseAttribute)));
             }
 
-            if (isDefined(test, typeof(HotfixAttribute)))
+            if (Utils.IsDefined(test, typeof(HotfixAttribute)))
             {
                 object cfg = get_cfg();
                 if (cfg is IEnumerable<Type>)
@@ -1408,17 +1399,17 @@ namespace CSObjectWrapEditor
                     }
                 }
             }
-            if (isDefined(test, typeof(BlackListAttribute))
+            if (Utils.IsDefined(test, typeof(BlackListAttribute))
                         && (typeof(List<List<string>>)).IsAssignableFrom(cfg_type))
             {
                 BlackList.AddRange(get_cfg() as List<List<string>>);
             }
-            if (isDefined(test, typeof(BlackListAttribute)) && typeof(Func<MemberInfo, bool>).IsAssignableFrom(cfg_type))
+            if (Utils.IsDefined(test, typeof(BlackListAttribute)) && typeof(Func<MemberInfo, bool>).IsAssignableFrom(cfg_type))
             {
                 memberFilters.Add(get_cfg() as Func<MemberInfo, bool>);
             }
 
-            if (isDefined(test, typeof(AdditionalPropertiesAttribute))
+            if (Utils.IsDefined(test, typeof(AdditionalPropertiesAttribute))
                         && (typeof(Dictionary<Type, List<string>>)).IsAssignableFrom(cfg_type))
             {
                 var cfg = get_cfg() as Dictionary<Type, List<string>>;
@@ -1431,7 +1422,7 @@ namespace CSObjectWrapEditor
                 }
             }
 
-            if (isDefined(test, typeof(DoNotGenAttribute))
+            if (Utils.IsDefined(test, typeof(DoNotGenAttribute))
                         && (typeof(Dictionary<Type, List<string>>)).IsAssignableFrom(cfg_type))
             {
                 var cfg = get_cfg() as Dictionary<Type, List<string>>;
@@ -1573,7 +1564,7 @@ namespace CSObjectWrapEditor
             {
                 foreach (var propInfo in type.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly))
                 {
-                    if ((AdditionalProperties.ContainsKey(type) && AdditionalProperties[type].Contains(propInfo.Name)) || isDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
+                    if ((AdditionalProperties.ContainsKey(type) && AdditionalProperties[type].Contains(propInfo.Name)) || Utils.IsDefined(propInfo, typeof(AdditionalPropertiesAttribute)))
                     {
                         int t_size = SizeOf(propInfo.PropertyType);
                         if (t_size == -1)

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Tencent is pleased to support the open source community by making xLua available.
  * Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
  * Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
@@ -320,8 +320,16 @@ namespace CSObjectWrapEditor
                     var overloads = new List<MethodBase>();
                     List<int> def_vals = new List<int>();
                     bool isOverride = false;
+                    bool isLuaCSFunc = false;
                     foreach (var overload in v.Cast<MethodBase>().OrderBy(mb => OverloadCosting(mb)))
                     {
+                        if(overload.IsDefined(typeof(LuaCSFunctionAttribute)))
+                        {
+                            isLuaCSFunc = true;
+                            overloads.Clear();
+                            overloads.Add(overload);
+                            break;
+                        }
                         int def_count = 0;
                         overloads.Add(overload);
                         def_vals.Add(def_count);
@@ -347,12 +355,13 @@ namespace CSObjectWrapEditor
                             }
                         }
                     }
-
-                    return new {
+                    return new
+                    {
                         Name = k,
                         IsStatic = overloads[0].IsStatic && (!isDefined(overloads[0], typeof(ExtensionAttribute)) || overloads[0].GetParameters()[0].ParameterType.IsInterface),
                         Overloads = overloads,
-                        DefaultValues = def_vals
+                        DefaultValues = def_vals,
+                        IsLuaCSFunc = isLuaCSFunc,
                     };
                 }).ToList());
 
@@ -1374,6 +1383,7 @@ namespace CSObjectWrapEditor
             {
                 AddToList(ReflectionUse, get_cfg, GetCustomAttribute(test, typeof(ReflectionUseAttribute)));
             }
+
             if (isDefined(test, typeof(HotfixAttribute)))
             {
                 object cfg = get_cfg();
@@ -1534,6 +1544,7 @@ namespace CSObjectWrapEditor
             { typeof(double), 8 },
             { typeof(decimal), 16 }
         };
+
 
         static int SizeOf(Type type)
         {

--- a/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
@@ -370,7 +370,38 @@ namespace XLua.CSObjectWrap
         [MonoPInvokeCallbackAttribute(typeof(LuaCSFunction))]
         static int _m_<%=method.Name%>(RealStatePtr L)
         {
-		    try {
+        <%if method.IsLuaCSFunc then %>
+#if LUACSFUNC_TRY_CATCH
+            try
+#endif
+            {
+            <%local overload = method.Overloads[0]%>
+            <%if not method.IsStatic then %>
+                ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
+                <%=GetSelfStatement(type)%>;
+                if (gen_to_be_invoked != null)
+                {   
+                    LuaAPI.lua_remove(L, 1);
+                    return gen_to_be_invoked.<%=UnK(overload.Name)%>(L);
+                }
+                else 
+                    return LuaAPI.luaL_error(L, "c# exception: Null Reference");
+            <%else%>
+                return <%=CsFullTypeName(type).."."..UnK(overload.Name)%>(L);
+            <%end%>
+            }
+#if LUACSFUNC_TRY_CATCH
+            catch (System.Reflection.TargetInvocationException e)
+            {
+                return LuaAPI.luaL_error(L, "c# exception:" + e.InnerException.Message + ",stack:" + e.InnerException.StackTrace);
+            }
+            catch (System.Exception e)
+            {
+                return LuaAPI.luaL_error(L, "c# exception:" + e.Message + ",stack:" + e.StackTrace);
+            }
+#endif
+        <%else%>
+            try {
             <%
             local need_obj = not method.IsStatic
             if MethodCallNeedTranslator(method) then
@@ -381,7 +412,7 @@ namespace XLua.CSObjectWrap
                 <%=GetSelfStatement(type)%>;
             <%end%>
             <%if method.Overloads.Count > 1 then%>
-			    int gen_param_count = LuaAPI.lua_gettop(L);
+                int gen_param_count = LuaAPI.lua_gettop(L);
             <%end%>
                 <%ForEachCsList(method.Overloads, function(overload, oi)
                 local parameters = MethodParameters(overload)
@@ -391,7 +422,7 @@ namespace XLua.CSObjectWrap
                 local in_pos = 0
                 local has_return = (overload.ReturnType.FullName ~= "System.Void")
                 local def_count = method.DefaultValues[oi]
-				local param_count = parameters.Length
+                local param_count = parameters.Length
                 local real_param_count = param_count - def_count
                 local has_v_params = param_count > 0 and IsParams(parameters[param_count - 1])
                 if method.Overloads.Count > 1 then
@@ -406,14 +437,14 @@ namespace XLua.CSObjectWrap
                     end)%>) <%end%>
                 {
                     <%if overload.Name == "get_Item" and overload.IsSpecialName then
-					    local keyType = overload:GetParameters()[0].ParameterType%>
-					<%=GetCasterStatement(keyType, 2, "key", true)%>;
-					<%=GetPushStatement(overload.ReturnType, "gen_to_be_invoked[key]")%>;
-					<%elseif overload.Name == "set_Item" and overload.IsSpecialName then
-					    local keyType = overload:GetParameters()[0].ParameterType
-						local valueType = overload:GetParameters()[1].ParameterType%>
-					<%=GetCasterStatement(keyType, 2, "key", true)%>;
-					<%=GetCasterStatement(valueType, 3, "gen_value", true)%>;
+                        local keyType = overload:GetParameters()[0].ParameterType%>
+                    <%=GetCasterStatement(keyType, 2, "key", true)%>;
+                    <%=GetPushStatement(overload.ReturnType, "gen_to_be_invoked[key]")%>;
+                    <%elseif overload.Name == "set_Item" and overload.IsSpecialName then
+                        local keyType = overload:GetParameters()[0].ParameterType
+                        local valueType = overload:GetParameters()[1].ParameterType%>
+                    <%=GetCasterStatement(keyType, 2, "key", true)%>;
+                    <%=GetCasterStatement(valueType, 3, "gen_value", true)%>;
                     gen_to_be_invoked[key] = gen_value;
                     <% else
                     in_pos = 0;
@@ -422,7 +453,7 @@ namespace XLua.CSObjectWrap
                         %><%if not (parameter.IsOut and parameter.ParameterType.IsByRef) then 
                             in_pos = in_pos + 1
                         %><%=GetCasterStatement(parameter.ParameterType, in_pos+param_offset, LocalName(parameter.Name), true, has_v_params and pi == param_count - 1)%><%
-					    else%><%=CsFullTypeName(parameter.ParameterType)%> <%=LocalName(parameter.Name)%><%end%>;
+                        else%><%=CsFullTypeName(parameter.ParameterType)%> <%=LocalName(parameter.Name)%><%end%>;
                     <%end)%>
                     <%
                     if has_return then
@@ -449,12 +480,12 @@ namespace XLua.CSObjectWrap
                         if parameter.ParameterType.IsByRef then
                         %><%=GetPushStatement(parameter.ParameterType:GetElementType(), LocalName(parameter.Name))%>;
                         <%if not parameter.IsOut and parameter.ParameterType.IsByRef and NeedUpdate(parameter.ParameterType) then 
-                  %><%=GetUpdateStatement(parameter.ParameterType:GetElementType(), in_pos+param_offset, LocalName(parameter.Name))%>;
+                %><%=GetUpdateStatement(parameter.ParameterType:GetElementType(), in_pos+param_offset, LocalName(parameter.Name))%>;
                         <%end%>
                     <%
                         end
                     end)
-					end
+                    end
                     %>
                     <%if NeedUpdate(type) and not method.IsStatic then%>
                         <%=GetUpdateStatement(type, 1, "gen_to_be_invoked")%>;
@@ -469,6 +500,7 @@ namespace XLua.CSObjectWrap
             <%if method.Overloads.Count > 1 then%>
             return LuaAPI.luaL_error(L, "invalid arguments to <%=CsFullTypeName(type)%>.<%=method.Overloads[0].Name%>!");
             <%end%>
+        <%end%>
         }
         <% end)%>
         

--- a/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
+++ b/Assets/XLua/Src/Editor/Template/LuaClassWrap.tpl.txt
@@ -379,13 +379,8 @@ namespace XLua.CSObjectWrap
             <%if not method.IsStatic then %>
                 ObjectTranslator translator = ObjectTranslatorPool.Instance.Find(L);
                 <%=GetSelfStatement(type)%>;
-                if (gen_to_be_invoked != null)
-                {   
-                    LuaAPI.lua_remove(L, 1);
-                    return gen_to_be_invoked.<%=UnK(overload.Name)%>(L);
-                }
-                else 
-                    return LuaAPI.luaL_error(L, "c# exception: Null Reference");
+                LuaAPI.lua_remove(L, 1);
+                return gen_to_be_invoked.<%=UnK(overload.Name)%>(L);
             <%else%>
                 return <%=CsFullTypeName(type).."."..UnK(overload.Name)%>(L);
             <%end%>

--- a/Assets/XLua/Src/GenAttributes.cs
+++ b/Assets/XLua/Src/GenAttributes.cs
@@ -83,7 +83,7 @@ namespace XLua
     {
         
     }
-
+    [AttributeUsage(AttributeTargets.Method)]
     public class LuaCSFunctionAttribute: Attribute
     {
 

--- a/Assets/XLua/Src/GenAttributes.cs
+++ b/Assets/XLua/Src/GenAttributes.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Tencent is pleased to support the open source community by making xLua available.
  * Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
  * Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
@@ -82,6 +82,11 @@ namespace XLua
     public class DoNotGenAttribute : Attribute
     {
         
+    }
+
+    public class LuaCSFunctionAttribute: Attribute
+    {
+
     }
 
     public class AdditionalPropertiesAttribute : Attribute

--- a/Assets/XLua/Src/MethodWarpsCache.cs
+++ b/Assets/XLua/Src/MethodWarpsCache.cs
@@ -344,7 +344,11 @@ namespace XLua
             }
             else
             {
+#if !UNITY_WSA || UNITY_EDITOR
+                var luaCSFunc = Delegate.CreateDelegate(typeof(LuaCSFunction), methodInfo) as LuaCSFunction;
+#else
                 var luaCSFunc = methodInfo.CreateDelegate(typeof(LuaCSFunction)) as LuaCSFunction;
+#endif
 #if LUACSFUNC_TRY_CATCH
                 toCall = (L) =>
                 {

--- a/Assets/XLua/Src/MethodWarpsCache.cs
+++ b/Assets/XLua/Src/MethodWarpsCache.cs
@@ -297,7 +297,15 @@ namespace XLua
             LuaCSFunction toCall;
             if (need_obj)
             {
-                var args = new object[1];
+                object[] args;
+                if(methodInfo.IsStatic)
+                {
+                    args = new object[2];
+                }
+                else
+                {
+                    args = new object[1];
+                }
                 toCall = (L) =>
                 {
 #if LUACSFUNC_TRY_CATCH
@@ -306,9 +314,21 @@ namespace XLua
                     {
 
                         object obj = translator.FastGetCSObj(L, 1);
-                        args[0] = L;
                         LuaAPI.lua_remove(L, 1);
-                        return (int)methodInfo.Invoke(obj, args);
+                        int ret = 0;
+                        if (methodInfo.IsStatic)
+                        {
+                            args[0] = obj;args[1] = L;
+                            ret = (int)methodInfo.Invoke(null, args);
+                            args[0] = null;args[1] = null;
+                        }
+                        else
+                        {
+                            args[0] = L;
+                            ret = (int)methodInfo.Invoke(obj, args);
+                            args[0] = null;
+                        }
+                        return ret;
                     }
 #if LUACSFUNC_TRY_CATCH
                     catch (System.Reflection.TargetInvocationException e)

--- a/Assets/XLua/Src/MethodWarpsCache.cs
+++ b/Assets/XLua/Src/MethodWarpsCache.cs
@@ -292,7 +292,7 @@ namespace XLua
 
         public static LuaCSFunction GenLuaCSFuncWrap(string methodName, MethodInfo methodInfo,ObjectTranslator translator)
         {
-            bool need_obj = methodInfo.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute)) ||
+            bool need_obj = Utils.IsDefined(methodInfo, typeof(System.Runtime.CompilerServices.ExtensionAttribute)) ||
                 !methodInfo.IsStatic;
             LuaCSFunction toCall;
             if (need_obj)

--- a/Assets/XLua/Src/MethodWarpsCache.cs
+++ b/Assets/XLua/Src/MethodWarpsCache.cs
@@ -298,7 +298,7 @@ namespace XLua
             if (need_obj)
             {
                 object[] args;
-                if(methodInfo.IsStatic)
+                if (methodInfo.IsStatic)
                 {
                     args = new object[2];
                 }
@@ -308,67 +308,33 @@ namespace XLua
                 }
                 toCall = (L) =>
                 {
-#if LUACSFUNC_TRY_CATCH
-                    try
-#endif
-                    {
 
-                        object obj = translator.FastGetCSObj(L, 1);
-                        LuaAPI.lua_remove(L, 1);
-                        int ret = 0;
-                        if (methodInfo.IsStatic)
-                        {
-                            args[0] = obj;args[1] = L;
-                            ret = (int)methodInfo.Invoke(null, args);
-                            args[0] = null;args[1] = null;
-                        }
-                        else
-                        {
-                            args[0] = L;
-                            ret = (int)methodInfo.Invoke(obj, args);
-                            args[0] = null;
-                        }
-                        return ret;
-                    }
-#if LUACSFUNC_TRY_CATCH
-                    catch (System.Reflection.TargetInvocationException e)
+                    object obj = translator.FastGetCSObj(L, 1);
+                    LuaAPI.lua_remove(L, 1);
+                    int ret = 0;
+                    if (methodInfo.IsStatic)
                     {
-                        return LuaAPI.luaL_error(L, "c# exception:" + e.InnerException.Message + ",stack:" + e.InnerException.StackTrace);
+                        args[0] = obj; args[1] = L;
+                        ret = (int)methodInfo.Invoke(null, args);
+                        args[0] = null; args[1] = null;
                     }
-                    catch (System.Exception e)
+                    else
                     {
-                        return LuaAPI.luaL_error(L, "c# exception:" + e.Message + ",stack:" + e.StackTrace);
+                        args[0] = L;
+                        ret = (int)methodInfo.Invoke(obj, args);
+                        args[0] = null;
                     }
-#endif
+                    return ret;
+
+
                 };
             }
             else
             {
 #if !UNITY_WSA || UNITY_EDITOR
-                var luaCSFunc = Delegate.CreateDelegate(typeof(LuaCSFunction), methodInfo) as LuaCSFunction;
+                toCall = Delegate.CreateDelegate(typeof(LuaCSFunction), methodInfo) as LuaCSFunction;
 #else
-                var luaCSFunc = methodInfo.CreateDelegate(typeof(LuaCSFunction)) as LuaCSFunction;
-#endif
-#if LUACSFUNC_TRY_CATCH
-                toCall = (L) =>
-                {
-                    try
-                    {
-                        return luaCSFunc(L);
-                    }
-
-                    catch (System.Reflection.TargetInvocationException e)
-                    {
-                        return LuaAPI.luaL_error(L, "c# exception:" + e.InnerException.Message + ",stack:" + e.InnerException.StackTrace);
-                    }
-                    catch (System.Exception e)
-                    {
-                        return LuaAPI.luaL_error(L, "c# exception:" + e.Message + ",stack:" + e.StackTrace);
-                    }
-                };
-
-#else
-                toCall = luaCSFunc;
+                toCall = methodInfo.CreateDelegate(typeof(LuaCSFunction)) as LuaCSFunction;
 #endif
             }
             return toCall;

--- a/Assets/XLua/Src/ObjectTranslator.cs
+++ b/Assets/XLua/Src/ObjectTranslator.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Tencent is pleased to support the open source community by making xLua available.
  * Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
  * Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -577,7 +577,7 @@ namespace XLua
 					for (int i = 0; i < kv.Value.Count; i++)
 					{
 						var method = kv.Value[i];
-						isLuaCSFunc = method.IsDefined(typeof(LuaCSFunctionAttribute));
+						isLuaCSFunc = IsDefined(method,typeof(LuaCSFunctionAttribute));
 						if (isLuaCSFunc)
 						{
 							if (kv.Value.Count > 1)
@@ -601,6 +601,15 @@ namespace XLua
 					LuaAPI.lua_rawset(L, kv.Key.IsStatic ? cls_field : obj_field);
 				}
 			}
+		}
+
+		public static bool IsDefined(MemberInfo test,Type attribute)
+		{
+#if XLUA_GENERAL
+            return test.GetCustomAttributes(false).Any(ca => ca.GetType().ToString() == attribute.ToString());
+#else
+			return test.IsDefined(attribute, false);
+#endif
 		}
 
 		public static void loadUpvalue(RealStatePtr L, Type type, string metafunc, int index)

--- a/Assets/XLua/Src/Utils.cs
+++ b/Assets/XLua/Src/Utils.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Tencent is pleased to support the open source community by making xLua available.
  * Copyright (C) 2016 THL A29 Limited, a Tencent company. All rights reserved.
  * Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
@@ -573,8 +573,31 @@ namespace XLua
 				else
 				{
 					LuaAPI.xlua_pushasciistring(L, kv.Key.Name);
-					translator.PushFixCSFunction(L,
-						new LuaCSFunction(translator.methodWrapsCache._GenMethodWrap(type, kv.Key.Name, kv.Value.ToArray()).Call));
+					bool isLuaCSFunc = false;
+					for (int i = 0; i < kv.Value.Count; i++)
+					{
+						var method = kv.Value[i];
+						isLuaCSFunc = method.IsDefined(typeof(LuaCSFunctionAttribute));
+						if (isLuaCSFunc)
+						{
+							if (kv.Value.Count > 1)
+							{
+								kv.Value.Clear();
+								kv.Value.Add(method);
+								//warning ..
+							}
+							break;
+						}
+					}
+					if (isLuaCSFunc)
+					{
+						translator.PushFixCSFunction(L,	MethodWrap.GenLuaCSFuncWrap(kv.Key.Name, kv.Value[0] as MethodInfo, translator));
+					}
+					else
+					{
+						translator.PushFixCSFunction(L,
+							new LuaCSFunction(translator.methodWrapsCache._GenMethodWrap(type, kv.Key.Name, kv.Value.ToArray()).Call));
+					}
 					LuaAPI.lua_rawset(L, kv.Key.IsStatic ? cls_field : obj_field);
 				}
 			}


### PR DESCRIPTION
增加了一个Attribute **[LuaCSFunctionAttribute]**用于标注方法。
被标注的方法会被当做LuaCSFunction来调用，支持静态方法、扩展方法、实例方法。
上述方法Wrap中通过宏 LUACSFUNC_TRY_CATCH 来控制是否使用TryCatch代码。
测试用例见：14_LuaCSFunction

目的：可以在函数中操作Lua栈，针对高频调用函数进行优化。
例如：将函数参数中的字符串拷贝到重用的buffer中，而非每次创建String。