### PR TITLE
Filter the use of pointers that are not supported.

### DIFF
--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -940,6 +940,8 @@ namespace CSObjectWrapEditor
                     .Where(method => !ignoreCompilerGenerated || !isDefined(method, typeof(CompilerGeneratedAttribute)))
                     .Where(method => !ignoreNotPublic || method.IsPublic)
                     .Where(method => !ignoreProperty || !method.IsSpecialName || (!method.Name.StartsWith("get_") && !method.Name.StartsWith("set_")))
+                    .Where(method => !method.GetParameters().Any(pInfo => pInfo.ParameterType.IsPointer))
+                    .Where(method => !method.ReturnType.IsPointer)
                     .Cast<MethodBase>()
                     .Concat(kv.Key.GetConstructors(bindingAttrOfConstructor).Cast<MethodBase>())
                     .Where(method => !injectByGeneric(method, kv.Value))

--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -737,6 +737,10 @@ namespace XLua
                 {
                     continue;
                 }
+                if (method.Parameters.Any(pd => pd.ParameterType.IsPointer) || method.ReturnType.IsPointer)
+                {
+                    continue;
+                }
                 if (method.Name != ".cctor" && !method.IsAbstract && !method.IsPInvokeImpl && method.Body != null && !method.Name.Contains("<"))
                 {
                     //Debug.Log(method);
@@ -763,6 +767,10 @@ namespace XLua
                         continue;
                     }
                     if (ignoreCompilerGenerated && method.CustomAttributes.Any(ca => ca.AttributeType.FullName == "System.Runtime.CompilerServices.CompilerGeneratedAttribute"))
+                    {
+                        continue;
+                    }
+                    if (method.Parameters.Any(pd => pd.ParameterType.IsPointer) || method.ReturnType.IsPointer)
                     {
                         continue;
                     }


### PR DESCRIPTION
I noticed that [v2.1.15](https://github.com/Tencent/xLua/releases/tag/v2.1.15f1) adds pointer filtering. This patch is to filter pointers in the code generation phase and the DLL injection phase. 