### PR TITLE
fix: (ExampleConfig.typeHasEditorRef) stackoverflow error

### DIFF
--- a/Assets/XLua/Editor/ExampleConfig.cs
+++ b/Assets/XLua/Editor/ExampleConfig.cs
@@ -187,6 +187,10 @@ public static class ExampleConfig
     //    {
     //        foreach (var typeArg in type.GetGenericArguments())
     //        {
+    //            if (typeArg.IsGenericParameter) {
+    //                //skip unsigned type parameter
+    //                continue;
+    //            } 
     //            if (typeHasEditorRef(typeArg))
     //            {
     //                return true;


### PR DESCRIPTION
当类型是开放类型的时候，在得到该类型的泛型参数后会再次调用泛型参数的declaringType代入函数，导致无限递归。

fix #865
fix #639  
泛型参数加上判断，略过开放的类型参数
