### PR TITLE
Fix使用RawObject处理byte[]作为函数参数时，byte[]为null的问题

### DIFF
--- a/Assets/XLua/Src/ObjectCasters.cs
+++ b/Assets/XLua/Src/ObjectCasters.cs
@@ -314,7 +314,12 @@ namespace XLua
 
         private object getBytes(RealStatePtr L, int idx, object target)
         {
-            return LuaAPI.lua_type(L, idx) == LuaTypes.LUA_TSTRING ? LuaAPI.lua_tobytes(L, idx) : translator.SafeGetCSObj(L, idx) as byte[];
+            if(LuaAPI.lua_type(L, idx) == LuaTypes.LUA_TSTRING)
+            {
+                return LuaAPI.lua_tobytes(L, idx);
+            }
+            object obj = translator.SafeGetCSObj(L, idx);
+            return (obj is RawObject) ? (obj as RawObject).Target : obj as byte[];
         }
 
         private object getIntptr(RealStatePtr L, int idx, object target)


### PR DESCRIPTION
在lua侧调用FileStream.Read(byte[] buffer, int offset, int length)接口, 无法正常获取buffer读到的值，需要用RawObject对象将byte[]包裹一下，类似下面这种方式。

 `
public class BytesRef : RawObject 
{

    byte[] data;

    public BytesRef(byte[] data)
    {
        this.data = data;
    }

    public BytesRef(int length)
    {
        data = new byte[length];
    }

    public object Target
    {
        get
        {
            return data;
        }
    }

    public byte this[int index]
    {
        get
        {
            return data[index];
        }
        set
        {
            data[index] = value;
        }
    }
}

`

然后在lua里面可以这样调用, 记得将xxx.bytes改成你的文件路径。

`

local buffer = CS.BytesRef(1024)
local path = "xxx.bytes"
local fs = CS.System.IO.FileStream(path, CS.System.IO.FileMode.Open)
local num = fs:Read(buffer, 0, 1024)
if num > 0 then
    print('num:' .. tostring(num))
    print('buffer:' .. buffer.Target)
end
fs:Close()

`

如果不对xLua ObjectCaster.cs中getBytes函数增加对RawObject类型处理，调用Read时会报错。



