### PR TITLE
修复多程序集在打包时注入时LuaEnv指向的程序集中的委托参数与当前被注入的函数的参数所依赖的DLL的PublicKeyToken不一致

### DIFF
--- a/Assets/XLua/Src/Editor/Hotfix.cs
+++ b/Assets/XLua/Src/Editor/Hotfix.cs
@@ -1691,7 +1691,7 @@ namespace XLua
                 }
             }
 
-            List<string> args = new List<string>() { assembly_csharp_path, typeof(LuaEnv).Module.FullyQualifiedName, id_map_file_path, hotfix_cfg_in_editor };
+            List<string> args = new List<string>() { assembly_csharp_path, Path.Combine(assemblyDir, typeof(LuaEnv).Module.Name), id_map_file_path, hotfix_cfg_in_editor };
 
             foreach (var path in
                 (from asm in AppDomain.CurrentDomain.GetAssemblies() select asm.ManifestModule.FullyQualifiedName)


### PR DESCRIPTION
修复多程序集在打包时注入时，LuaEnv指向的程序集中的委托参数与当前被注入的函数的参数所依赖的DLL的PublicKeyToken不一致无法匹配对应的参数，导致注入失败的问题。