### PR TITLE
屏蔽匿名方法的生成， 屏蔽Protected参数的方法生成

### DIFF
--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -900,7 +900,14 @@ namespace CSObjectWrapEditor
         {
             string filePath = save_path + "DelegatesGensBridge.cs";
             StreamWriter textWriter = new StreamWriter(filePath, false, Encoding.UTF8);
-            types = types.Where(type => !type.GetMethod("Invoke").GetParameters().Any(paramInfo => paramInfo.ParameterType.IsGenericParameter));
+
+            types = types
+                .Where(type =>
+                    !type.GetMethod("Invoke").GetParameters()
+                        .Any(paramInfo => paramInfo.ParameterType.IsGenericParameter | 
+                                          (paramInfo.ParameterType.IsNested & paramInfo.ParameterType.IsNestedFamily)))
+                .Where(type => !type.FullName.Contains("<>f__"));
+
             var hotfxDelegates = new List<MethodInfoSimulation>();
             var comparer = new MethodInfoSimulationComparer();
 


### PR DESCRIPTION
整合FairyGUI的时候， 用CodeGen生成代码，发现匿名方法， 还有Protected类型也会生成， 但是这样会导致编译错误，这里就屏蔽了匿名方法， 和Protected类型的方法生成