### PR TITLE
* fixes issue #1036

### DIFF
--- a/Assets/XLua/Src/ObjectTranslator.cs
+++ b/Assets/XLua/Src/ObjectTranslator.cs
@@ -1233,7 +1233,13 @@ namespace XLua
                 LuaAPI.lua_pushnil(L);
                 return;
             }
-
+#if UNITY_EDITOR
+            if (o is UnityEngine.Object && ((o as UnityEngine.Object) == null))
+            {
+                LuaAPI.lua_pushnil(L);
+                return;
+            }
+#endif
             int index = -1;
             Type type = o.GetType();
 #if !UNITY_WSA || UNITY_EDITOR


### PR DESCRIPTION
- 需要参考 Unity 2019 引擎源代码中 GetComponent.cpp 的实现
- 推测 Unity 为了返回的错误信息更详细，这里返回了虽然 == null，但是不是 null 的对象。
- Unity 引擎仅在 UNITY_EDITOR 宏下如此处理