### PR TITLE
* 修复5.4.6报错 memory_leak_checker.c(153,4): error C2440: 'initializing'…

### DIFF
--- a/build/memory_leak_checker.c
+++ b/build/memory_leak_checker.c
@@ -150,7 +150,11 @@ LUA_API void xlua_report_object_relationship(lua_State *L, ObjectRelationshipRep
 		{
 			LClosure *cl = gco2lcl(p);
 			lua_lock(L);
+#if LUA_VERSION_NUM >= 504
+			setclLvalue2s(L, L->top.p, cl);
+#else
 			setclLvalue(L, L->top, cl);
+#endif
 			api_incr_top(L);
 			lua_unlock(L);
 			


### PR DESCRIPTION
…: cannot convert from 'StkIdRel' to 'TValue *'

[https://github.com/Tencent/xLua/issues/1079](url)