### PR TITLE
fix: 修复在 Unity 2022 下生成代码报 Span 无法作泛型参数的问题

### DIFF
--- a/Assets/XLua/Editor/XLuaUnityDefaultConfig.cs
+++ b/Assets/XLua/Editor/XLuaUnityDefaultConfig.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using XLua;
+
+/// <summary>
+/// xLua 默认配置
+/// </summary>
+static class XLuaUnityDefaultConfig
+{
+
+#if UNITY_2022_1_OR_NEWER
+    static bool IsSpanType(Type type)
+    {
+        if (!type.IsGenericType)
+            return false;
+
+        var genericDefinition = type.GetGenericTypeDefinition();
+
+        return
+            genericDefinition == typeof(Span<>) ||
+            genericDefinition == typeof(ReadOnlySpan<>);
+    }
+
+    static bool IsSpanMember(MemberInfo memberInfo)
+    {
+        switch (memberInfo)
+        {
+            case FieldInfo fieldInfo:
+                return IsSpanType(fieldInfo.FieldType);
+
+            case PropertyInfo propertyInfo:
+                return IsSpanType(propertyInfo.PropertyType);
+
+            case ConstructorInfo constructorInfo:
+                return constructorInfo.GetParameters().Any(p => IsSpanType(p.ParameterType));
+
+            case MethodInfo methodInfo:
+                return methodInfo.GetParameters().Any(p => IsSpanType(p.ParameterType)) || IsSpanType(methodInfo.ReturnType);
+
+            default:
+                return false;
+        }
+    }
+
+    [BlackList]
+    public static Func<MemberInfo, bool> SpanMembersFilter = IsSpanMember;
+
+#endif
+}


### PR DESCRIPTION
在 Assets/XLua/Editor 目录下创建了适用于 Unity 的 xLua 默认配置. 它将在环境为 Unity 2022 或更高版本时, 屏蔽 Span<T> 和 ReadOnlySpan<T> 相关的所有成员的生成