### PR TITLE
修复lua5.4.6，构建iOS平台时出现报错（'system' is unavailable: not available on iOS）

### DIFF
--- a/build/CMakeLists.txt
+++ b/build/CMakeLists.txt
@@ -145,6 +145,7 @@ source_group_by_dir(${CMAKE_CURRENT_SOURCE_DIR} XLUA_CORE)
 
 if (APPLE)
     if (IOS)
+        ADD_DEFINITIONS(-DLUA_USE_IOS) # Despite claiming to be ISO C, iOS does not implement 'system'.(iOS11)
         set(CMAKE_OSX_ARCHITECTURES "$(ARCHS_STANDARD)")
         add_library(xlua STATIC
            ${LUA_CORE}


### PR DESCRIPTION
xLua升级lua5.4.6，出现编译报错：'system' is unavailable: not available on iOS。
相关代码：lua5.4.6源码中的loslib.c line: 134中对其进行了解释。
故，cmake编译时需要增加宏LUA_USE_IOS。