### PR TITLE
Blacklist all methods with specific keyword

### DIFF
--- a/Assets/XLua/Doc/Configure_EN.md
+++ b/Assets/XLua/Doc/Configure_EN.md
@@ -120,6 +120,9 @@ public static List<List<string>> BlackList = new List<List<string>>()  {
     //new List<string>(){ typeof(UnityEngine.GameObject).FullName, "networkView"},
     new List<string>(){"System.IO.FileInfo", "GetAccessControl", "System.Security.AccessControl.AccessControlSections"},
     //new List<string>(){ typeof(System.IO.FileInfo).FullName, "GetAccessControl",typeof(System.Security.AccessControl.AccessControlSections).FullName },
+
+    // If you want to blacklist all methods with specific name, use "All" as first parameter type:
+    new List<string>() { "UnityEngine.Debug", "Log",  "All" },
 };
 ~~~
 

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -566,6 +566,8 @@ namespace CSObjectWrapEditor
             {
                 if (mb.DeclaringType.ToString() == exclude[0] && mb.Name == exclude[1])
                 {
+                    if(exclude.Count == 3 && string.Equals(exclude[2], "All")
+                        return true; // Blacklist all methods with this name;
                     var parameters = mb.GetParameters();
                     if (parameters.Length != exclude.Count - 2)
                     {


### PR DESCRIPTION
Since I wanted to blacklist some methods and I didn't care about overloaded versions of it, I found it tedious to list all parameters even if there are no overloaded methods. And even if there were some, it would be nice to be able to blacklist all of them without specifying all of possible parameters.

The keyword 'All' is just a placeholder, it can be changed to whatever simple word.

I updated readme also, but only the english version. The original readme should be updated also, but I do not speak the language.