### PR TITLE
修复以支持包含布尔字段的 [GCOptimize] 结构体

### DIFF
--- a/Assets/XLua/Src/CopyByValue.cs
+++ b/Assets/XLua/Src/CopyByValue.cs
@@ -31,6 +31,16 @@ namespace XLua
         {
             return LuaAPI.xlua_unpack_int8_t(buff, offset, out field);
         }
+        public static bool Pack(IntPtr buff, int offset, bool field)
+        {
+            return LuaAPI.xlua_pack_int8_t(buff, offset, field ? (byte)1 : (byte)0);
+        }
+        public static bool UnPack(IntPtr buff, int offset, out bool field)
+        {
+            bool ret = LuaAPI.xlua_unpack_int8_t(buff, offset, out byte tfield);
+            field = tfield != 0;
+            return ret;
+        }
         public static bool Pack(IntPtr buff, int offset, sbyte field)
         {
             return LuaAPI.xlua_pack_int8_t(buff, offset, (byte)field);

--- a/Assets/XLua/Src/Editor/Generator.cs
+++ b/Assets/XLua/Src/Editor/Generator.cs
@@ -1524,6 +1524,7 @@ namespace CSObjectWrapEditor
 
         static Dictionary<Type, int> type_size = new Dictionary<Type, int>()
         {
+            { typeof(bool), 1 },
             { typeof(byte), 1 },
             { typeof(sbyte), 1 },
             { typeof(short), 2 },


### PR DESCRIPTION
没有这个改动，任何带有 [GCOptimize] 标记且包含布尔字段的结构体都会导致内存分配，因为 Generator.SizeOf 将返回 -1。