### PR TITLE
修复例子在Unity6000的打包错误

### DIFF
--- a/Assets/XLua/Examples/ExampleGenConfig.cs
+++ b/Assets/XLua/Examples/ExampleGenConfig.cs
@@ -75,11 +75,9 @@ public static class ExampleGenConfig
                 new List<string>(){"UnityEngine.CanvasRenderer", "onRequestRebuild"},
                 new List<string>(){"UnityEngine.Light", "areaSize"},
                 new List<string>(){"UnityEngine.Light", "lightmapBakeType"},
-    #if UNITY_ANDROID || UNITY_6000_0_OR_NEWER
                 new List<string>(){"UnityEngine.Light", "SetLightDirty"},
                 new List<string>(){"UnityEngine.Light", "shadowRadius"},
                 new List<string>(){"UnityEngine.Light", "shadowAngle"},
-    #endif
                 new List<string>(){"UnityEngine.WWW", "MovieTexture"},
                 new List<string>(){"UnityEngine.WWW", "GetMovieTexture"},
                 new List<string>(){"UnityEngine.AnimatorOverrideController", "PerformOverrideClipListCleanup"},
@@ -127,4 +125,5 @@ public static class ExampleGenConfig
         }
     };
 }
+
 


### PR DESCRIPTION
```
Assets\XLua\Gen\UnityEngine_LightWrap.cs(831,60): error CS1061: 'Light' does not contain a definition for 'shadowAngle' and no accessible extension method 'shadowAngle' accepting a first argument of type 'Light' could be found (are you missing a using directive or an assembly reference?)

Assets\XLua\Gen\UnityEngine_LightWrap.cs(1371,35): error CS1061: 'Light' does not contain a definition for 'shadowRadius' and no accessible extension method 'shadowRadius' accepting a first argument of type 'Light' could be found (are you missing a using directive or an assembly reference?)

Assets\XLua\Gen\UnityEngine_LightWrap.cs(1386,35): error CS1061: 'Light' does not contain a definition for 'shadowAngle' and no accessible extension method 'shadowAngle' accepting a first argument of type 'Light' could be found (are you missing a using directive or an assembly reference?)


```

通过查询文档，这三个属性是Editor only的，在新版本Unity中打包会直接报错。